### PR TITLE
Relax python-dotenv constraint to >=1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 google~=3.0.0
 protobuf~=5.29.5
 grpcio~=1.73.1
-python-dotenv~=1.0.1
+python-dotenv>=1.1.0
 Faker~=25.8.0
 grpcio-status~=1.66.2
 requests~=2.32.3

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "protoc-gen-openapiv2>=0.0.1",
         "googleapis-common-protos>=1.56.1,<1.66.0",
         "deprecation>=2.1.0",
-        "python-dotenv~=1.0.1",
+        "python-dotenv>=1.1.0",
         "Faker~=25.8.0",
         "pydantic~=2.10.6",
         "langchain-core>=0.3.36,<0.4",


### PR DESCRIPTION
I’m integrating ScaleKit OAuth into a Graphiti MCP server that relies on FastMCP’s middleware API (mcp.add_middleware, added in FastMCP 2.9+). FastMCP ≥2.9 requires python-dotenv >=1.1.0. Your SDK currently requires python-dotenv ~=1.0.1, which creates a hard resolver conflict.

Evidence from my build:
ERROR: The conflict is caused by:
  fastmcp 2.12.0 depends on python-dotenv>=1.1.0
  scalekit-sdk-python 2.3.3 depends on python-dotenv~=1.0.1

Minimal steps to reproduce:
pip install "fastmcp>=2.9" "scalekit-sdk-python==2.3.3" "python-dotenv==1.1.1"
# -> resolver error as above

Suggested change (setup.cfg / pyproject / setup.py):
# before
python-dotenv~=1.0.1
# after
python-dotenv>=1.1.0

FastMCP’s middleware is the clean way to attach auth, logging, and policy around MCP ops. It is officially documented as “New in version 2.9.0.” I need a single environment for MCP + OAuth to avoid cross-service glue. Is there any way you could relax the python-dotenv requirement to >=1.1.0 (or drop it as a hard dependency if only used for examples)? You’d need to publish a patch release with the updated constraint. The current SDK release line is 2.3.x on PyPI. A small patch would unblock modern FastMCP servers. 

If there’s an internal reason for the ~=1.0.1 cap, I can adapt by not using your service, but a broader range aligns with current ecosystem baselines.