### PR TITLE
Use string literal type annotations for TemplateType and DomainType

### DIFF
--- a/scalekit/domain.py
+++ b/scalekit/domain.py
@@ -13,7 +13,7 @@ _DOMAIN_TYPE_MAP = {
     "ORGANIZATION_DOMAIN": DomainType.ORGANIZATION_DOMAIN,
 }
 
-def _convert_domain_type(domain_type: Union[str, DomainType, None]) -> Optional[DomainType]:
+def _convert_domain_type(domain_type: Union[str, "DomainType", None]) -> Optional["DomainType"]:
     """Convert string or enum to DomainType enum"""
     if domain_type is None:
         return None
@@ -44,7 +44,7 @@ class DomainClient:
         )
 
     def create_domain(
-        self, organization_id: str, domain_name: str, domain_type: Optional[Union[str, DomainType]] = None
+        self, organization_id: str, domain_name: str, domain_type: Optional[Union[str, "DomainType"]] = None
     ) -> CreateDomainResponse:
         """
         Method to create domain

--- a/scalekit/passwordless.py
+++ b/scalekit/passwordless.py
@@ -13,7 +13,7 @@ _TEMPLATE_TYPE_MAP = {
     "SIGNUP": TemplateType.SIGNUP,
 }
 
-def _convert_template_type(template: Union[str, TemplateType, None]) -> Optional[TemplateType]:
+def _convert_template_type(template: Union[str, "TemplateType", None]) -> Optional["TemplateType"]:
     """Convert string or enum to TemplateType enum"""
     if template is None:
         return None
@@ -46,7 +46,7 @@ class PasswordlessClient:
     def send_passwordless_email(
         self,
         email: str,
-        template: Optional[Union[str, TemplateType]] = None,
+        template: Optional[Union[str, "TemplateType"]] = None,
         magiclink_auth_uri: Optional[str] = None,
         state: Optional[str] = None,
         expires_in: Optional[int] = None,


### PR DESCRIPTION
Use string literal type annotations for TemplateType and DomainType to avoid import-time evaluation issues with protobuf-generated enums.