### PR TITLE
feat: add search_users method to user client (FIN-271)

### DIFF
--- a/scalekit/users.py
+++ b/scalekit/users.py
@@ -22,6 +22,8 @@ from scalekit.v1.users.users_pb2 import (
     ListUsersResponse,
     ResendInviteRequest,
     ResendInviteResponse,
+    SearchUsersRequest,
+    SearchUsersResponse,
     UpdateMembership,
     UpdateMembershipRequest,
     UpdateMembershipResponse,
@@ -126,6 +128,34 @@ class UserClient:
         return self.core_client.grpc_exec(
             self.user_service.ListUsers.with_call,
             ListUsersRequest(
+                page_size=page_size,
+                page_token=page_token
+            ),
+        )
+
+    def search_users(
+        self,
+        query: str,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None
+    ) -> SearchUsersResponse:
+        """
+        Method to search users in environment using a query string
+
+        :param query           : Search query string to match users
+        :type                  : ``` str ```
+        :param page_size       : Page size for pagination
+        :type                  : ``` int ```
+        :param page_token      : Page token for pagination
+        :type                  : ``` str ```
+
+        :returns:
+            Search Users Response
+        """
+        return self.core_client.grpc_exec(
+            self.user_service.SearchUsers.with_call,
+            SearchUsersRequest(
+                query=query,
                 page_size=page_size,
                 page_token=page_token
             ),


### PR DESCRIPTION
## Summary
- Adds `search_users(query, page_size=None, page_token=None)` to the user client, wrapping the already-generated `SearchUsers` gRPC stub.
- Supports pagination consistent with the existing `list_users` method.

Closes FIN-271.

## Test plan
- [ ] `python -m pytest tests/test_users.py`
- [ ] Manual smoke test: `scalekit_client.users.search_users(query='john', page_size=10)`

<!-- generated-by-cyrus -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user search functionality with support for query-based filtering and pagination controls to efficiently manage large result sets.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/scalekit-sdk-python/pull/156)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->