### PR TITLE
feat(org): add slug integration tests

### DIFF
--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -114,6 +114,32 @@ class TestOrganization(BaseTest):
         self.assertEqual(response[0].organization.metadata, metadata)
         self.assertEqual(response[0].organization.external_id, external_id)
 
+    def test_create_organization_with_slug(self):
+        """ Method to test create organization with slug """
+        import time
+        slug = f"test-slug-{int(time.time() * 1000)}"
+        display_name = Faker().company()
+        organization = CreateOrganization(display_name=display_name, slug=slug)
+        response = self.scalekit_client.organization.create_organization(organization=organization)
+        self.assertEqual(response[1].code().name, "OK")
+        self.assertEqual(response[0].organization.slug, slug)
+        self.org_id = response[0].organization.id
+
+    def test_update_organization_with_slug(self):
+        """ Method to test update organization with slug """
+        import time
+        organization = CreateOrganization(display_name=Faker().company(), external_id=Faker().uuid4())
+        org_response = self.scalekit_client.organization.create_organization(organization=organization)
+        self.org_id = org_response[0].organization.id
+
+        slug = f"upd-slug-{int(time.time() * 1000)}"
+        update_organization = UpdateOrganization(slug=slug)
+        response = self.scalekit_client.organization.update_organization(
+            organization_id=self.org_id, organization=update_organization
+        )
+        self.assertEqual(response[1].code().name, "OK")
+        self.assertEqual(response[0].organization.slug, slug)
+
     def test_delete_organization(self):
         """ Method to test delete organization """
         organization = CreateOrganization(display_name=Faker().company(), external_id=Faker().uuid4())


### PR DESCRIPTION
## Summary
- `slug` is already present in the generated proto types (`CreateOrganization`, `UpdateOrganization`, `Organization`)
- Add integration tests to verify slug round-trips correctly through create and update

## Test plan
- [ ] `test_create_organization_with_slug` — sets slug on `CreateOrganization`, asserts `response[0].organization.slug` matches
- [ ] `test_update_organization_with_slug` — sets slug on `UpdateOrganization`, asserts updated value is returned

Run with staging credentials:
```
SCALEKIT_ENV_URL=... SCALEKIT_CLIENT_ID=... SCALEKIT_CLIENT_SECRET=... \
  pytest tests/test_organization.py::TestOrganization::test_create_organization_with_slug \
         tests/test_organization.py::TestOrganization::test_update_organization_with_slug -v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for organization slug functionality to ensure slug creation and updates work as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scalekit-inc/scalekit-sdk-python/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->