### PR TITLE
chore: bump version to 2.11.0

### DIFF
--- a/scalekit/_version.py
+++ b/scalekit/_version.py
@@ -1,3 +1,3 @@
 # Single source of truth for the SDK version.
 # Import this in setup.py and scalekit/core.py — never hardcode the version elsewhere.
-__version__ = "2.10.0"
+__version__ = "2.11.0"


### PR DESCRIPTION
## Summary
- Bump SDK version from 2.10.0 to 2.11.0

## Test plan
- [ ] Version reflects correctly in `scalekit/_version.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 2.11.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->