### PR TITLE
[SK-636] chore(deps): align grpcio + grpcio-status to >=1.81.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version=__version__,
     packages=find_packages(),
     install_requires=[
-        "grpcio>=1.64.1",
+        "grpcio>=1.81.0",
         "protobuf>=5.29.5,<7.0.0",
         "google>=3.0",
         "requests>=2.34.0",
@@ -18,7 +18,7 @@ setup(
         "cffi>=1.15.1",
         "cryptography==46.0.6,<47",
         "setuptools>=78.1.1,<83.0",
-        "grpcio-status>=1.64,<1.67",
+        "grpcio-status>=1.81.0,<2.0",
         "protoc-gen-openapiv2>=0.0.1",
         "googleapis-common-protos>=1.72.0",
         "deprecation>=2.1.0",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version=__version__,
     packages=find_packages(),
     install_requires=[
-        "grpcio>=1.81.0",
+        "grpcio>=1.81.0,<2.0",
         "protobuf>=5.29.5,<7.0.0",
         "google>=3.0",
         "requests>=2.34.0",


### PR DESCRIPTION
## Summary

Aligns `grpcio` and `grpcio-status` to the same version floor (`>=1.81.0`) to eliminate a runtime version mismatch.

Linear: https://linear.app/scalekit/issue/SK-636

### Changes

| Package | From | To | Notes |
|---------|------|----|-------|
| `grpcio` | `>=1.64.1` | `>=1.81.0` | Bump lower bound to match grpcio-status; was already resolving to 1.81.0 in practice |
| `grpcio-status` | `>=1.64,<1.67` | `>=1.81.0,<2.0` | **Critical**: `<1.67` cap was blocking 1.67–1.81.0, causing a mismatch with grpcio |

### Why this matters

`grpcio` had no upper cap and pip was installing 1.81.0. `grpcio-status` was capped at `<1.67`, so pip installed 1.66.x — a known-bad combination where `rpc_status.from_call()` can return `None` instead of a Status object, crashing the exception handler in `scalekit/common/exceptions.py:95`.

The `<2.0` safety cap on `grpcio-status` prevents accidentally jumping to a future incompatible major version.

### Test Results

`pip install -e .` resolves cleanly. `pip check` reports no broken requirements.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgYGK5yazi8z8WkDw3zWQu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised minimum version requirements for gRPC-related dependencies to align with current stable releases and long-term support, including widening the accepted range for the status package to newer stable releases. This helps ensure compatibility, improved stability, and security with recent gRPC updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->