### PR TITLE
[SK-641] chore(deps): unpin cryptography to >=46.0.6,<49

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "requests>=2.34.0",
         "PyJWT>=2.13.0",
         "cffi>=1.15.1",
-        "cryptography==46.0.6,<47",
+        "cryptography>=46.0.6,<49",
         "setuptools>=78.1.1,<83.0",
         "grpcio-status>=1.81.0,<2.0",
         "protoc-gen-openapiv2>=0.0.1",


### PR DESCRIPTION
## Summary

Unpins `cryptography` from an exact version lock that was blocking all security patches in 47.x and 48.x.

Linear: https://linear.app/scalekit/issue/SK-641

### Changes

| Package | From | To | Notes |
|---------|------|----|-------|
| `cryptography` | `==46.0.6,<47` | `>=46.0.6,<49` | Allows 47.x and 48.x (latest: 48.0.1); adds `<49` safety cap |

### Why this matters

`cryptography` is a security-critical library (TLS, JWT signing, SAML). Pinning it to exactly `==46.0.6` meant users could not receive security patches released in 47.x or 48.x. The new constraint `>=46.0.6,<49` allows pip to resolve to the latest compatible patch while capping at the next major version boundary.

### Test Results

`pip check` reports no broken requirements with the new constraint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgYGK5yazi8z8WkDw3zWQu)_