### PR TITLE
[SK-642] chore(deps): bump protobuf upper bound to >=5.29.5,<8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "grpcio>=1.81.0,<2.0",
-        "protobuf>=5.29.5,<7.0.0",
+        "protobuf>=5.29.5,<8.0.0",
         "google>=3.0",
         "requests>=2.34.0",
         "PyJWT>=2.13.0",


### PR DESCRIPTION
## Summary

Allows pip to resolve `protobuf` to the actively maintained 7.x series (latest: 7.35.0) by lifting the `<7.0.0` ceiling.

Linear: https://linear.app/scalekit/issue/SK-642

### Changes

| Package | From | To | Notes |
|---------|------|----|-------|
| `protobuf` | `>=5.29.5,<7.0.0` | `>=5.29.5,<8.0.0` | Allows 7.x (latest: 7.35.0); keeps `<8.0.0` safety cap |

### Why this matters

The current constraint `<7.0.0` blocks the entire 7.x release series, which is the actively maintained stable line from the protobuf project. Users are locked to 5.x/6.x builds and cannot receive bugfixes or improvements in 7.x.

protobuf 7.x maintains backwards compatibility with generated code from protoc 5.x. The SDK only uses public generated gRPC stubs (`pkg/grpc/`), so there are no known breakage points.

### Test Results

`pip check` reports no broken requirements with the new constraint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgYGK5yazi8z8WkDw3zWQu)_