### PR TITLE
[SK-657] chore(deps): bump cffi >=1.15.1 → >=2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "google>=3.0",
         "requests>=2.34.0",
         "PyJWT>=2.13.0",
-        "cffi>=1.15.1",
+        "cffi>=2.0.0",
         "cryptography>=46.0.6,<49",
         "setuptools>=82.0.1,<83.0",
         "grpcio-status>=1.81.0,<2.0",


### PR DESCRIPTION
## Summary

Linear: [SK-657](https://linear.app/scalekit/issue/SK-657)

Bumps `cffi` minimum bound from `>=1.15.1` to `>=2.0.0`.

| Package | From | To | Risk |
|---------|------|----|------|
| `cffi` | `>=1.15.1` | `>=2.0.0` | Medium (major version) |

### Why this is safe

- `cryptography>=46.0.6` (already required by this SDK) hard-requires cffi 2.0+, meaning **all current SDK consumers already have cffi 2.0.0 installed** — this change makes the explicit constraint consistent with reality
- The SDK does not call any cffi API directly; cffi is only used transitively via `cryptography`
- cffi 2.0.0 only drops Python 2 support — this SDK requires Python 3

## Test plan

- [x] `make lint` passes (static compile check)
- [x] `make setup` installs cleanly with cffi 2.0.0
- [x] No cffi API calls in SDK source — zero code changes needed
- [ ] Integration tests require live `SCALEKIT_ENV_URL` credentials (pre-existing, unaffected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgYGK5yazi8z8WkDw3zWQu)_