### PR TITLE
fix(SK-819, SK-821): provider error differentiation, blind retry fix, and upsert credentials

### DIFF
--- a/scalekit/_version.py
+++ b/scalekit/_version.py
@@ -1,3 +1,3 @@
 # Single source of truth for the SDK version.
 # Import this in setup.py and scalekit/core.py — never hardcode the version elsewhere.
-__version__ = "2.12.0"
+__version__ = "2.13.0"

--- a/scalekit/actions/actions.py
+++ b/scalekit/actions/actions.py
@@ -791,10 +791,22 @@ class ActionClient:
                 organization_id=organization_id,
                 user_id=user_id
             )
-            
-            # If we found it, convert the GetConnectedAccountAuthResponse to CreateConnectedAccountResponse format
+
+            # True upsert: if credentials were supplied, apply them regardless of
+            # the account's current status (PENDING_AUTH, ACTIVE, EXPIRED, DISCONNECTED).
+            if authorization_details:
+                update_response = self.update_connected_account(
+                    connection_name=connection_name,
+                    identifier=identifier,
+                    authorization_details=authorization_details,
+                    organization_id=organization_id,
+                    user_id=user_id,
+                    api_config=api_config
+                )
+                return CreateConnectedAccountResponse(connected_account=update_response.connected_account)
+
             return CreateConnectedAccountResponse(connected_account=existing_response.connected_account)
-            
+
         except ScalekitNotFoundException:
             # Connected account doesn't exist, create a new one
             return self.create_connected_account(
@@ -805,6 +817,9 @@ class ActionClient:
                 user_id=user_id,
                 api_config=api_config
             )
+
+    #: Alias for :meth:`get_or_create_connected_account` — preferred name for upsert semantics.
+    upsert_connected_account = get_or_create_connected_account
 
     def update_connected_account(
         self,

--- a/scalekit/common/exceptions.py
+++ b/scalekit/common/exceptions.py
@@ -104,9 +104,39 @@ class ScalekitServerException(ScalekitException):
                     self._error_code = info.error_code
 
     @staticmethod
+    def _extract_error_code(error: grpc.RpcError) -> str | None:
+        """ Extract error_code from gRPC trailing metadata without constructing a full exception """
+        from grpc_status import rpc_status
+        try:
+            status = rpc_status.from_call(error)
+            if status is None:
+                return None
+            for detail in status.details:
+                info = ErrorInfo()
+                detail.Unpack(info)
+                if info.error_code:
+                    return info.error_code
+        except Exception:
+            pass
+        return None
+
+    @staticmethod
     def promote(error: Response | grpc.RpcError):
         """ Promote a ScalekitServerException (Response or RpcError) to a specific error type """
         grpc_status = HTTP_TO_GRPC.get(error.status_code) if isinstance(error, Response) else error.code()
+
+        # Check for upstream provider errors signaled by error_code == "TOOL_ERROR"
+        if isinstance(error, grpc.RpcError):
+            error_code = ScalekitServerException._extract_error_code(error)
+            if error_code == "TOOL_ERROR":
+                if grpc_status == StatusCode.RESOURCE_EXHAUSTED:
+                    return ScalekitToolRateLimitException(error)
+                elif grpc_status == StatusCode.UNAUTHENTICATED:
+                    return ScalekitToolUnauthorizedException(error)
+                elif grpc_status == StatusCode.PERMISSION_DENIED:
+                    return ScalekitToolForbiddenException(error)
+                else:
+                    return ScalekitToolException(error)
 
         if grpc_status == StatusCode.INVALID_ARGUMENT:
             return ScalekitBadRequestException(error)
@@ -258,3 +288,52 @@ class ScalekitCancelledException(ScalekitServerException):
 class ScalekitUnknownException(ScalekitServerException):
     def __init__(self, error: Response | grpc.RpcError):
         super().__init__(error)
+
+
+class ScalekitToolException(ScalekitServerException):
+    """ Base class for upstream provider tool errors (error_code == 'TOOL_ERROR') """
+    def __init__(self, error: Response | grpc.RpcError):
+        super().__init__(error)
+        # Extract ToolErrorInfo from the unpacked ErrorInfo details
+        self._tool_error_code = None
+        self._tool_error_message = None
+        self._execution_id = None
+        for info in self._unpacked_details:
+            if info.HasField("tool_error_info"):
+                self._tool_error_code = info.tool_error_info.tool_error_code or None
+                self._tool_error_message = info.tool_error_info.tool_error_message or None
+                self._execution_id = info.tool_error_info.execution_id or None
+                break
+
+    @property
+    def tool_error_code(self):
+        """ Provider-specific error code from tool execution """
+        return self._tool_error_code
+
+    @property
+    def tool_error_message(self):
+        """ Provider-specific error message from tool execution """
+        return self._tool_error_message
+
+    @property
+    def execution_id(self):
+        """ Execution ID for the tool call that failed """
+        return self._execution_id
+
+
+class ScalekitToolRateLimitException(ScalekitToolException, ScalekitTooManyRequestsException):
+    """ Provider returned 429/rate-limit during tool execution """
+    def __init__(self, error: Response | grpc.RpcError):
+        ScalekitToolException.__init__(self, error)
+
+
+class ScalekitToolUnauthorizedException(ScalekitToolException, ScalekitUnauthorizedException):
+    """ Provider returned 401/unauthorized during tool execution """
+    def __init__(self, error: Response | grpc.RpcError):
+        ScalekitToolException.__init__(self, error)
+
+
+class ScalekitToolForbiddenException(ScalekitToolException, ScalekitForbiddenException):
+    """ Provider returned 403/forbidden during tool execution """
+    def __init__(self, error: Response | grpc.RpcError):
+        ScalekitToolException.__init__(self, error)

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -10,7 +10,7 @@ from urllib.parse import urlparse
 from cryptography.hazmat.primitives import serialization
 from scalekit._version import __version__ as _sdk_version
 from scalekit.common.scalekit import GrantType
-from scalekit.common.exceptions import ScalekitServerException, ScalekitException
+from scalekit.common.exceptions import ScalekitServerException, ScalekitException, ScalekitTooManyRequestsException
 
 TRequest = TypeVar("TRequest")
 TResponse = TypeVar("TResponse")
@@ -163,6 +163,11 @@ class CoreClient:
             )
             return resp
         except grpc.RpcError as exp:
+            # Check for upstream provider errors first — never retry, never refresh M2M
+            error_code = ScalekitServerException._extract_error_code(exp)
+            if error_code == "TOOL_ERROR":
+                raise ScalekitServerException.promote(exp)
+
             if exp.code() == grpc.StatusCode.UNAUTHENTICATED:
                 if retry <= 0:
                     raise ScalekitServerException.promote(exp)
@@ -171,6 +176,9 @@ class CoreClient:
                     return self.grpc_exec(func, data, retry=retry-1)
                 except Exception as refresh_exp:
                     raise ScalekitServerException.promote(exp)
+            elif exp.code() == grpc.StatusCode.RESOURCE_EXHAUSTED:
+                # Surface Scalekit rate-limits immediately — retrying triples the damage
+                raise ScalekitServerException.promote(exp)
             elif retry > 0:
                 return self.grpc_exec(func, data, retry=retry - 1)
             else:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -348,7 +348,7 @@ class TestConnect(BaseTest):
         """Method to test execute_tool with connection_name parameter"""
         try:
             result = self.scalekit_client.actions.execute_tool(
-                tool_input={"url": "https://docs.apify.com/platform/storage/usage"},
+                tool_input={"url": "https://docs.apify.com/platform/storage"},
                 tool_name="c-myapifymcp_fetch-apify-docs",
                 identifier="akshay.parihar",
                 connection_name="myapifymcp",

--- a/tests/test_sk819_retry_behavior.py
+++ b/tests/test_sk819_retry_behavior.py
@@ -1,0 +1,442 @@
+"""
+SK-819: Provider error handling tests.
+
+Phase 1: Tests for CURRENT behavior (must pass before any changes).
+Phase 2: Tests for NEW behavior (must fail before implementation, then pass after).
+"""
+import unittest
+from unittest.mock import MagicMock, patch, call
+import grpc
+from grpc import StatusCode
+
+from google.rpc import status_pb2
+from google.protobuf import any_pb2
+
+from scalekit.v1.errdetails.errdetails_pb2 import ErrorInfo, ToolErrorInfo
+from scalekit.common.exceptions import (
+    ScalekitServerException,
+    ScalekitTooManyRequestsException,
+    ScalekitUnauthorizedException,
+    ScalekitForbiddenException,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_rpc_error(status_code: StatusCode, error_code: str = None,
+                    tool_error_code: str = None, tool_error_message: str = None,
+                    execution_id: str = None, message: str = "error"):
+    """Build a mock grpc.RpcError with optional TOOL_ERROR details."""
+    details = []
+    if error_code is not None:
+        tool_error_info = None
+        if tool_error_code or tool_error_message or execution_id:
+            tool_error_info = ToolErrorInfo(
+                execution_id=execution_id or "",
+                tool_error_message=tool_error_message or "",
+                tool_error_code=tool_error_code or "",
+            )
+        kwargs = {"error_code": error_code}
+        if tool_error_info:
+            kwargs["tool_error_info"] = tool_error_info
+        info = ErrorInfo(**kwargs)
+        detail = any_pb2.Any()
+        detail.Pack(info)
+        details.append(detail)
+
+    status = status_pb2.Status(
+        code=status_code.value[0],
+        message=message,
+        details=details,
+    )
+    trailing = (("grpc-status-details-bin", status.SerializeToString()),)
+
+    class _FakeRpcError(grpc.RpcError):
+        def code(self):
+            return status_code
+
+        def trailing_metadata(self):
+            return trailing
+
+        def details(self):
+            return message
+
+    return _FakeRpcError()
+
+
+def _make_core_client():
+    """Return a CoreClient instance with __init__ bypassed (no real network calls)."""
+    from scalekit.core import CoreClient
+    client = CoreClient.__new__(CoreClient)
+    client.access_token = "test-token"
+    client.host = "example.com"
+    client.env_url = "https://example.com"
+    client.client_id = "cid"
+    client.client_secret = "csec"
+    client.keys = {}
+    client.grpc_secure_channel = None
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Current behavior tests (must ALL pass before any code changes)
+# ---------------------------------------------------------------------------
+
+class TestPhase1CurrentBehavior(unittest.TestCase):
+    """
+    Document and verify behavior. Originally written as pre-fix baseline;
+    P1-1 still holds unchanged. P1-2, P1-3, P1-4 document WHAT WAS WRONG
+    (bugs now fixed) — they are rewritten to assert the correct post-fix behavior
+    so that the suite remains green and serves as regression tests.
+    """
+
+    def setUp(self):
+        self.client = _make_core_client()
+
+    def _mock_func(self, side_effects):
+        """Helper that creates a callable raising side_effects in sequence."""
+        calls = iter(side_effects)
+
+        def func(data, metadata):
+            effect = next(calls)
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+
+        return func
+
+    # ------------------------------------------------------------------
+    # P1-1: Scalekit UNAUTHENTICATED (no TOOL_ERROR) → M2M refresh + retry
+    #       (behavior unchanged by the fix)
+    # ------------------------------------------------------------------
+    def test_p1_scalekit_unauthenticated_triggers_m2m_refresh_and_retry(self):
+        """Scalekit 401 (no TOOL_ERROR) must call __authenticate_client and retry."""
+        unauth_error = _make_rpc_error(StatusCode.UNAUTHENTICATED)  # no error_code
+        success_response = object()
+
+        func = self._mock_func([unauth_error, success_response])
+
+        with patch.object(self.client, "_CoreClient__authenticate_client") as mock_auth:
+            result = self.client.grpc_exec(func, data=None, retry=2)
+
+        mock_auth.assert_called_once()
+        self.assertIs(result, success_response)
+
+    # ------------------------------------------------------------------
+    # P1-2: Provider 429 (RESOURCE_EXHAUSTED + TOOL_ERROR)
+    #       PRE-FIX BUG: was retried 3x then raised ScalekitTooManyRequestsException
+    #       POST-FIX: raises ScalekitToolRateLimitException immediately (no retry)
+    # ------------------------------------------------------------------
+    def test_p1_provider_429_now_raises_tool_rate_limit_immediately(self):
+        """
+        Post-fix: RESOURCE_EXHAUSTED + TOOL_ERROR raises ScalekitToolRateLimitException
+        immediately with no retries.
+        """
+        from scalekit.common.exceptions import ScalekitToolRateLimitException
+        tool_429 = _make_rpc_error(
+            StatusCode.RESOURCE_EXHAUSTED,
+            error_code="TOOL_ERROR",
+            tool_error_code="RATE_LIMIT_EXCEEDED",
+            tool_error_message="Provider rate limited",
+            execution_id="exec-001",
+        )
+        call_count = [0]
+
+        def func(data, metadata):
+            call_count[0] += 1
+            raise tool_429
+
+        with self.assertRaises(ScalekitToolRateLimitException):
+            self.client.grpc_exec(func, data=None, retry=2)
+
+        # No retry — exactly 1 call
+        self.assertEqual(call_count[0], 1)
+
+    # ------------------------------------------------------------------
+    # P1-3: Provider 401 (UNAUTHENTICATED + TOOL_ERROR)
+    #       PRE-FIX BUG: triggered M2M refresh
+    #       POST-FIX: raises ScalekitToolUnauthorizedException immediately, no M2M
+    # ------------------------------------------------------------------
+    def test_p1_provider_401_now_raises_tool_unauthorized_immediately(self):
+        """
+        Post-fix: UNAUTHENTICATED + TOOL_ERROR raises ScalekitToolUnauthorizedException
+        immediately, without triggering M2M token refresh.
+        """
+        from scalekit.common.exceptions import ScalekitToolUnauthorizedException
+        tool_401 = _make_rpc_error(
+            StatusCode.UNAUTHENTICATED,
+            error_code="TOOL_ERROR",
+            tool_error_code="UNAUTHORIZED",
+            tool_error_message="Provider unauthorized",
+            execution_id="exec-002",
+        )
+        call_count = [0]
+
+        def func(data, metadata):
+            call_count[0] += 1
+            raise tool_401
+
+        with patch.object(self.client, "_CoreClient__authenticate_client") as mock_auth:
+            with self.assertRaises(ScalekitToolUnauthorizedException):
+                self.client.grpc_exec(func, data=None, retry=1)
+
+        mock_auth.assert_not_called()
+        self.assertEqual(call_count[0], 1)
+
+    # ------------------------------------------------------------------
+    # P1-4: Scalekit 429 (RESOURCE_EXHAUSTED, no TOOL_ERROR)
+    #       PRE-FIX BUG: was retried (tripling rate-limit damage)
+    #       POST-FIX: raises ScalekitTooManyRequestsException immediately
+    # ------------------------------------------------------------------
+    def test_p1_scalekit_429_now_surfaces_immediately(self):
+        """
+        Post-fix: plain RESOURCE_EXHAUSTED (no TOOL_ERROR) is surfaced immediately
+        as ScalekitTooManyRequestsException without any retries.
+        """
+        scalekit_429 = _make_rpc_error(StatusCode.RESOURCE_EXHAUSTED)  # no error_code
+        call_count = [0]
+
+        def func(data, metadata):
+            call_count[0] += 1
+            raise scalekit_429
+
+        with self.assertRaises(ScalekitTooManyRequestsException):
+            self.client.grpc_exec(func, data=None, retry=2)
+
+        # No retry — exactly 1 call
+        self.assertEqual(call_count[0], 1)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: New behavior tests (must FAIL before implementation)
+# ---------------------------------------------------------------------------
+
+class TestPhase2NewBehavior(unittest.TestCase):
+    """Tests for desired (post-fix) behavior. These should FAIL before the fix."""
+
+    def setUp(self):
+        self.client = _make_core_client()
+
+    def _always_raise(self, exc):
+        call_count = [0]
+
+        def func(data, metadata):
+            call_count[0] += 1
+            raise exc
+
+        return func, call_count
+
+    # ------------------------------------------------------------------
+    # Exception hierarchy tests
+    # ------------------------------------------------------------------
+    def test_p2_tool_rate_limit_exception_exists(self):
+        """ScalekitToolRateLimitException must exist in exceptions module."""
+        from scalekit.common.exceptions import ScalekitToolRateLimitException  # noqa
+
+    def test_p2_tool_unauthorized_exception_exists(self):
+        """ScalekitToolUnauthorizedException must exist in exceptions module."""
+        from scalekit.common.exceptions import ScalekitToolUnauthorizedException  # noqa
+
+    def test_p2_tool_forbidden_exception_exists(self):
+        """ScalekitToolForbiddenException must exist in exceptions module."""
+        from scalekit.common.exceptions import ScalekitToolForbiddenException  # noqa
+
+    def test_p2_tool_exception_exists(self):
+        """ScalekitToolException must exist in exceptions module."""
+        from scalekit.common.exceptions import ScalekitToolException  # noqa
+
+    def test_p2_tool_rate_limit_is_instance_of_too_many_requests(self):
+        """ScalekitToolRateLimitException is instance of ScalekitTooManyRequestsException (backward compat)."""
+        from scalekit.common.exceptions import ScalekitToolRateLimitException, ScalekitToolException
+        assert issubclass(ScalekitToolRateLimitException, ScalekitTooManyRequestsException)
+        assert issubclass(ScalekitToolRateLimitException, ScalekitToolException)
+
+    def test_p2_tool_unauthorized_is_instance_of_unauthorized(self):
+        """ScalekitToolUnauthorizedException is instance of ScalekitUnauthorizedException (backward compat)."""
+        from scalekit.common.exceptions import ScalekitToolUnauthorizedException, ScalekitToolException
+        assert issubclass(ScalekitToolUnauthorizedException, ScalekitUnauthorizedException)
+        assert issubclass(ScalekitToolUnauthorizedException, ScalekitToolException)
+
+    def test_p2_tool_forbidden_is_instance_of_forbidden(self):
+        """ScalekitToolForbiddenException is instance of ScalekitForbiddenException (backward compat)."""
+        from scalekit.common.exceptions import ScalekitToolForbiddenException, ScalekitToolException
+        assert issubclass(ScalekitToolForbiddenException, ScalekitForbiddenException)
+        assert issubclass(ScalekitToolForbiddenException, ScalekitToolException)
+
+    def test_p2_tool_exception_has_tool_error_code_property(self):
+        """ScalekitToolException exposes tool_error_code property."""
+        from scalekit.common.exceptions import ScalekitToolException
+        rpc_err = _make_rpc_error(
+            StatusCode.RESOURCE_EXHAUSTED,
+            error_code="TOOL_ERROR",
+            tool_error_code="RATE_LIMIT_EXCEEDED",
+            tool_error_message="Provider rate limited",
+            execution_id="exec-123",
+        )
+        exc = ScalekitToolException(rpc_err)
+        self.assertEqual(exc.tool_error_code, "RATE_LIMIT_EXCEEDED")
+
+    def test_p2_tool_exception_has_tool_error_message_property(self):
+        """ScalekitToolException exposes tool_error_message property."""
+        from scalekit.common.exceptions import ScalekitToolException
+        rpc_err = _make_rpc_error(
+            StatusCode.RESOURCE_EXHAUSTED,
+            error_code="TOOL_ERROR",
+            tool_error_code="RATE_LIMIT_EXCEEDED",
+            tool_error_message="Provider rate limited",
+            execution_id="exec-123",
+        )
+        exc = ScalekitToolException(rpc_err)
+        self.assertEqual(exc.tool_error_message, "Provider rate limited")
+
+    def test_p2_tool_exception_has_execution_id_property(self):
+        """ScalekitToolException exposes execution_id property."""
+        from scalekit.common.exceptions import ScalekitToolException
+        rpc_err = _make_rpc_error(
+            StatusCode.RESOURCE_EXHAUSTED,
+            error_code="TOOL_ERROR",
+            tool_error_code="RATE_LIMIT_EXCEEDED",
+            tool_error_message="Provider rate limited",
+            execution_id="exec-123",
+        )
+        exc = ScalekitToolException(rpc_err)
+        self.assertEqual(exc.execution_id, "exec-123")
+
+    # ------------------------------------------------------------------
+    # Retry behavior: provider errors must raise immediately (no retry)
+    # ------------------------------------------------------------------
+    def test_p2_provider_429_raises_tool_rate_limit_immediately_no_retry(self):
+        """Provider 429 (RESOURCE_EXHAUSTED + TOOL_ERROR) must raise ScalekitToolRateLimitException immediately, no retry."""
+        from scalekit.common.exceptions import ScalekitToolRateLimitException
+        rpc_err = _make_rpc_error(
+            StatusCode.RESOURCE_EXHAUSTED,
+            error_code="TOOL_ERROR",
+            tool_error_code="RATE_LIMIT_EXCEEDED",
+            tool_error_message="Provider rate limited",
+            execution_id="exec-001",
+        )
+        func, call_count = self._always_raise(rpc_err)
+
+        with self.assertRaises(ScalekitToolRateLimitException):
+            self.client.grpc_exec(func, data=None, retry=2)
+
+        # Must NOT be retried — exactly 1 call
+        self.assertEqual(call_count[0], 1)
+
+    def test_p2_provider_401_raises_tool_unauthorized_immediately_no_m2m_refresh(self):
+        """Provider 401 (UNAUTHENTICATED + TOOL_ERROR) must raise ScalekitToolUnauthorizedException immediately, no M2M refresh."""
+        from scalekit.common.exceptions import ScalekitToolUnauthorizedException
+        rpc_err = _make_rpc_error(
+            StatusCode.UNAUTHENTICATED,
+            error_code="TOOL_ERROR",
+            tool_error_code="UNAUTHORIZED",
+            tool_error_message="Provider unauthorized",
+            execution_id="exec-002",
+        )
+        func, call_count = self._always_raise(rpc_err)
+
+        with patch.object(self.client, "_CoreClient__authenticate_client") as mock_auth:
+            with self.assertRaises(ScalekitToolUnauthorizedException):
+                self.client.grpc_exec(func, data=None, retry=2)
+
+        mock_auth.assert_not_called()
+        self.assertEqual(call_count[0], 1)
+
+    def test_p2_provider_403_raises_tool_forbidden_immediately(self):
+        """Provider 403 (PERMISSION_DENIED + TOOL_ERROR) must raise ScalekitToolForbiddenException immediately."""
+        from scalekit.common.exceptions import ScalekitToolForbiddenException
+        rpc_err = _make_rpc_error(
+            StatusCode.PERMISSION_DENIED,
+            error_code="TOOL_ERROR",
+            tool_error_code="FORBIDDEN",
+            tool_error_message="Provider forbidden",
+            execution_id="exec-003",
+        )
+        func, call_count = self._always_raise(rpc_err)
+
+        with self.assertRaises(ScalekitToolForbiddenException):
+            self.client.grpc_exec(func, data=None, retry=2)
+
+        self.assertEqual(call_count[0], 1)
+
+    def test_p2_other_provider_error_raises_tool_exception_immediately(self):
+        """Any other TOOL_ERROR (e.g. INTERNAL) raises ScalekitToolException immediately."""
+        from scalekit.common.exceptions import ScalekitToolException
+        rpc_err = _make_rpc_error(
+            StatusCode.INTERNAL,
+            error_code="TOOL_ERROR",
+            tool_error_code="PROVIDER_ERROR",
+            tool_error_message="Provider internal error",
+            execution_id="exec-004",
+        )
+        func, call_count = self._always_raise(rpc_err)
+
+        with self.assertRaises(ScalekitToolException):
+            self.client.grpc_exec(func, data=None, retry=2)
+
+        self.assertEqual(call_count[0], 1)
+
+    def test_p2_tool_rate_limit_exception_carries_metadata(self):
+        """ScalekitToolRateLimitException carries tool_error_code, tool_error_message, execution_id."""
+        from scalekit.common.exceptions import ScalekitToolRateLimitException
+        rpc_err = _make_rpc_error(
+            StatusCode.RESOURCE_EXHAUSTED,
+            error_code="TOOL_ERROR",
+            tool_error_code="RATE_LIMIT_EXCEEDED",
+            tool_error_message="HubSpot rate limit hit",
+            execution_id="exec-hubspot-001",
+        )
+        func, _ = self._always_raise(rpc_err)
+
+        with self.assertRaises(ScalekitToolRateLimitException) as ctx:
+            self.client.grpc_exec(func, data=None, retry=2)
+
+        exc = ctx.exception
+        self.assertEqual(exc.tool_error_code, "RATE_LIMIT_EXCEEDED")
+        self.assertEqual(exc.tool_error_message, "HubSpot rate limit hit")
+        self.assertEqual(exc.execution_id, "exec-hubspot-001")
+
+    # ------------------------------------------------------------------
+    # Non-tool errors: Scalekit UNAUTHENTICATED must still refresh + retry
+    # ------------------------------------------------------------------
+    def test_p2_scalekit_unauthenticated_no_tool_error_still_refreshes(self):
+        """Scalekit 401 without TOOL_ERROR must still trigger M2M refresh (unchanged behavior)."""
+        unauth_error = _make_rpc_error(StatusCode.UNAUTHENTICATED)  # no error_code
+        success_response = object()
+        call_count = [0]
+
+        def func(data, metadata):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise unauth_error
+            return success_response
+
+        with patch.object(self.client, "_CoreClient__authenticate_client") as mock_auth:
+            result = self.client.grpc_exec(func, data=None, retry=2)
+
+        mock_auth.assert_called_once()
+        self.assertIs(result, success_response)
+
+    # ------------------------------------------------------------------
+    # Scalekit 429 (no TOOL_ERROR) must surface immediately, no retry
+    # ------------------------------------------------------------------
+    def test_p2_scalekit_429_no_tool_error_surfaces_immediately(self):
+        """Scalekit RESOURCE_EXHAUSTED without TOOL_ERROR must raise immediately (no retry)."""
+        scalekit_429 = _make_rpc_error(StatusCode.RESOURCE_EXHAUSTED)  # no error_code
+        call_count = [0]
+
+        def func(data, metadata):
+            call_count[0] += 1
+            raise scalekit_429
+
+        with self.assertRaises(ScalekitTooManyRequestsException):
+            self.client.grpc_exec(func, data=None, retry=2)
+
+        # Must surface immediately — exactly 1 call
+        self.assertEqual(call_count[0], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes SK-819 — blind retries and missing provider error differentiation for tool execution errors.

- **No retry for provider errors**: `grpc_exec` now checks `error_code == "TOOL_ERROR"` from gRPC `ErrorInfo` details before any retry decision. Provider errors raise immediately — no more 3x retry amplification on provider 429s.
- **New exception hierarchy**: `ScalekitToolException` base (extends `ScalekitServerException`) with typed subclasses via multiple inheritance for full backward + forward compat:
  - `ScalekitToolRateLimitException(ScalekitToolException, ScalekitTooManyRequestsException)` — provider 429
  - `ScalekitToolUnauthorizedException(ScalekitToolException, ScalekitUnauthorizedException)` — provider 401
  - `ScalekitToolForbiddenException(ScalekitToolException, ScalekitForbiddenException)` — provider 403
  - `ScalekitToolException` directly — any other provider error
- **Scalekit 429 surfaces immediately**: `RESOURCE_EXHAUSTED` without `TOOL_ERROR` no longer retried — caller owns retry strategy.
- **M2M refresh only for Scalekit 401**: `UNAUTHENTICATED` without `TOOL_ERROR` still refreshes token and retries. Provider 401 raises `ScalekitToolUnauthorizedException` immediately.

## Backward compatibility

Existing `except ScalekitTooManyRequestsException` blocks still catch `ScalekitToolRateLimitException` via inheritance. No customer code changes required unless they want the new granular exception types.

**Behavior change to note in release notes:** Provider errors previously retried up to 3 times now surface immediately. Scalekit 429s also surface immediately instead of retrying.

## Test plan

- [x] 21 new tests in `tests/test_sk819_retry_behavior.py` — all passing
- [x] Phase 1: baseline behavior documented and verified before implementation
- [x] Phase 2: new behavior tests written first (failing), then implementation made them pass
- [x] Full existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added upsert-style connected account handling when authorization details are provided (including an `upsert` alias).
  * Introduced tool-specific exception classes for clearer handling of provider tool failures (rate limit, unauthorized, forbidden).

* **Bug Fixes**
  * Improved retry behavior to immediately fail on tool-related errors instead of attempting refresh/retry.
  * Refined resource-exhaustion handling to avoid incorrect retry loops.

* **Chores**
  * Bumped the SDK version to **2.13.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->