### PR TITLE
SK-1210: Add gRPC deadline + backoff retry for dead-connection UNAVAILABLE errors

### DIFF
--- a/scalekit/_version.py
+++ b/scalekit/_version.py
@@ -1,3 +1,3 @@
 # Single source of truth for the SDK version.
 # Import this in setup.py and scalekit/core.py — never hardcode the version elsewhere.
-__version__ = "2.13.0"
+__version__ = "2.14.0"

--- a/scalekit/actions/actions.py
+++ b/scalekit/actions/actions.py
@@ -479,6 +479,11 @@ class ActionClient:
         :param headers: Additional HTTP headers to merge into the request
         :type headers: Optional[Dict[str, str]]
 
+        Pass ``timeout`` (seconds) via ``**kwargs`` to override the default request
+        timeout, which is ``ScalekitClient(..., tool_timeout_ms=...)`` (60s by default)
+        since this proxies to a third-party API and can legitimately run longer than
+        a typical control-plane call.
+
         :returns:
             requests.Response — the raw HTTP response; call .json(), .text,
             .status_code, .headers, etc. as needed
@@ -505,8 +510,9 @@ class ActionClient:
             proxy_headers.update(headers)
         req_headers = core.get_headers(proxy_headers)
 
-        # add default timeout and allow override via kwargs
-        timeout = kwargs.pop("timeout", 30)
+        # Default timeout mirrors tool_timeout_ms (proxies to a third-party API and can
+        # legitimately run longer); allow override via kwargs for a per-call value.
+        timeout = kwargs.pop("timeout", core.tool_timeout_ms / 1000)
 
         response = requests.request(
             method=method.upper(),

--- a/scalekit/client.py
+++ b/scalekit/client.py
@@ -49,7 +49,14 @@ webhook_signature_version = "v1"
 class ScalekitClient:
     """ Class definition for scalekit client """
 
-    def __init__(self, env_url: str, client_id: str, client_secret: str):
+    def __init__(
+        self,
+        env_url: str,
+        client_id: str,
+        client_secret: str,
+        timeout_ms: Optional[int] = None,
+        tool_timeout_ms: Optional[int] = None,
+    ):
         """
         Initializer for Scalekit base class
 
@@ -59,13 +66,27 @@ class ScalekitClient:
         :type                 : ``` str ```
         :param client_secret  : Client Secret
         :type                 : ``` str ```
+        :param timeout_ms     : gRPC call deadline in ms for control-plane RPCs (organizations,
+                                 users, connections, etc). Set below your infrastructure backend
+                                 timeout (e.g. GCP LB = 30s) so the SDK surfaces a clean error.
+                                 Defaults to 20000 (20s).
+        :type                 : ``` int ```
+        :param tool_timeout_ms : gRPC call deadline in ms for tool-execution RPCs (ToolsClient,
+                                  ActionClient.execute_tool/request), which proxy to third-party
+                                  provider APIs and can legitimately run longer. Defaults to 60000 (60s).
+        :type                 : ``` int ```
 
         :returns:
             None
         """
         try:
+            core_kwargs = {}
+            if timeout_ms is not None:
+                core_kwargs["timeout_ms"] = timeout_ms
+            if tool_timeout_ms is not None:
+                core_kwargs["tool_timeout_ms"] = tool_timeout_ms
             self.core_client = CoreClient(
-                env_url=env_url, client_id=client_id, client_secret=client_secret)
+                env_url=env_url, client_id=client_id, client_secret=client_secret, **core_kwargs)
             self.domain = DomainClient(self.core_client)
             self.connection = ConnectionClient(self.core_client)
             self.organization = OrganizationClient(self.core_client)

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -1,3 +1,5 @@
+import random
+import time
 from typing import TypeVar, Optional, Protocol
 
 import grpc
@@ -19,9 +21,22 @@ TMetadata = TypeVar("TMetadata")
 TOKEN_ENDPOINT = "/oauth/token"
 JWKS_ENDPOINT = "/keys"
 
+# gRPC call deadline for control-plane RPCs (organizations, users, connections, etc).
+# Kept below typical infra timeouts (e.g. GCP LB = 30s) so the SDK surfaces a clean
+# DeadlineExceeded error rather than a raw TCP abort on a silently dropped connection.
+DEFAULT_TIMEOUT_MS = 20_000
+
+# gRPC call deadline for tool-execution RPCs (ToolsClient / ActionClient.execute_tool,
+# ActionClient.request). These proxy to third-party provider APIs (Google Calendar,
+# Slack, etc.) and can legitimately run longer than typical control-plane calls, so
+# they use their own, longer deadline instead of DEFAULT_TIMEOUT_MS.
+DEFAULT_TOOL_TIMEOUT_MS = 60_000
+
 
 class WithCall(Protocol):
-    def __call__(self, request: TRequest, metadata: TMetadata) -> TResponse: ...
+    def __call__(
+        self, request: TRequest, metadata: TMetadata, timeout: Optional[float] = None
+    ) -> TResponse: ...
 
 
 class CoreClient:
@@ -32,7 +47,14 @@ class CoreClient:
     api_version = "20260603"
     user_agent = f"{sdk_version} Python/{platform.python_version()} ({platform.system()}; {platform.architecture()}"
 
-    def __init__(self, env_url, client_id, client_secret):
+    def __init__(
+        self,
+        env_url,
+        client_id,
+        client_secret,
+        timeout_ms: int = DEFAULT_TIMEOUT_MS,
+        tool_timeout_ms: int = DEFAULT_TOOL_TIMEOUT_MS,
+    ):
         """
         Initializer for Core client
 
@@ -42,6 +64,11 @@ class CoreClient:
         :type                 : ``` str ```
         :param client_secret  : Client Secret
         :type                 : ``` str ```
+        :param timeout_ms     : gRPC call deadline in ms for control-plane RPCs. Defaults to 20000 (20s).
+        :type                 : ``` int ```
+        :param tool_timeout_ms : gRPC call deadline in ms for tool-execution RPCs, which proxy to
+                                  third-party provider APIs and can legitimately run longer. Defaults to 60000 (60s).
+        :type                 : ``` int ```
         :returns
             None
         """
@@ -50,6 +77,8 @@ class CoreClient:
         self.env_url = env_url
         self.client_id = client_id
         self.client_secret = client_secret
+        self.timeout_ms = timeout_ms
+        self.tool_timeout_ms = tool_timeout_ms
         self.keys = {}
         self.access_token = None
         self.grpc_secure_channel = None
@@ -155,11 +184,18 @@ class CoreClient:
         func: WithCall,
         data: TRequest,
         retry=2,
+        attempt=0,
+        timeout_ms: Optional[int] = None,
     ) -> TResponse:
+        effective_timeout_ms = timeout_ms if timeout_ms is not None else self.timeout_ms
+        timeout_seconds = (
+            effective_timeout_ms / 1000 if effective_timeout_ms and effective_timeout_ms > 0 else None
+        )
         try:
             resp = func(
                 data,
                 metadata=tuple(self.get_headers().items()),
+                timeout=timeout_seconds,
             )
             return resp
         except grpc.RpcError as exp:
@@ -173,14 +209,20 @@ class CoreClient:
                     raise ScalekitServerException.promote(exp)
                 try:
                     self.__authenticate_client()
-                    return self.grpc_exec(func, data, retry=retry-1)
+                    return self.grpc_exec(func, data, retry=retry-1, attempt=attempt + 1, timeout_ms=timeout_ms)
                 except Exception as refresh_exp:
                     raise ScalekitServerException.promote(exp)
             elif exp.code() == grpc.StatusCode.RESOURCE_EXHAUSTED:
                 # Surface Scalekit rate-limits immediately — retrying triples the damage
                 raise ScalekitServerException.promote(exp)
+            elif exp.code() == grpc.StatusCode.UNAVAILABLE and retry > 0:
+                # Retry transient infrastructure errors with backoff, mirroring the Node SDK.
+                base_backoff = min(1 * 2 ** attempt, 30)
+                backoff_seconds = base_backoff * (0.5 + random.random() * 0.5)
+                time.sleep(backoff_seconds)
+                return self.grpc_exec(func, data, retry=retry - 1, attempt=attempt + 1, timeout_ms=timeout_ms)
             elif retry > 0:
-                return self.grpc_exec(func, data, retry=retry - 1)
+                return self.grpc_exec(func, data, retry=retry - 1, attempt=attempt + 1, timeout_ms=timeout_ms)
             else:
                 raise ScalekitServerException.promote(exp)
         except Exception as exp:

--- a/scalekit/tools.py
+++ b/scalekit/tools.py
@@ -51,6 +51,7 @@ class ToolsClient:
                 page_size=page_size,
                 page_token=page_token
             ),
+            timeout_ms=self.core_client.tool_timeout_ms,
         )
 
 
@@ -87,6 +88,7 @@ class ToolsClient:
                 page_size=page_size,
                 page_token=page_token
             ),
+            timeout_ms=self.core_client.tool_timeout_ms,
         )
 
     def execute_tool(
@@ -130,4 +132,5 @@ class ToolsClient:
                 connected_account_id=connected_account_id,
                 connector=connection_name
             ),
+            timeout_ms=self.core_client.tool_timeout_ms,
         )

--- a/tests/test_sk819_retry_behavior.py
+++ b/tests/test_sk819_retry_behavior.py
@@ -68,7 +68,7 @@ def _make_rpc_error(status_code: StatusCode, error_code: str = None,
 
 def _make_core_client():
     """Return a CoreClient instance with __init__ bypassed (no real network calls)."""
-    from scalekit.core import CoreClient
+    from scalekit.core import CoreClient, DEFAULT_TIMEOUT_MS, DEFAULT_TOOL_TIMEOUT_MS
     client = CoreClient.__new__(CoreClient)
     client.access_token = "test-token"
     client.host = "example.com"
@@ -77,6 +77,8 @@ def _make_core_client():
     client.client_secret = "csec"
     client.keys = {}
     client.grpc_secure_channel = None
+    client.timeout_ms = DEFAULT_TIMEOUT_MS
+    client.tool_timeout_ms = DEFAULT_TOOL_TIMEOUT_MS
     return client
 
 
@@ -99,7 +101,7 @@ class TestPhase1CurrentBehavior(unittest.TestCase):
         """Helper that creates a callable raising side_effects in sequence."""
         calls = iter(side_effects)
 
-        def func(data, metadata):
+        def func(data, metadata, timeout=None):
             effect = next(calls)
             if isinstance(effect, Exception):
                 raise effect
@@ -144,7 +146,7 @@ class TestPhase1CurrentBehavior(unittest.TestCase):
         )
         call_count = [0]
 
-        def func(data, metadata):
+        def func(data, metadata, timeout=None):
             call_count[0] += 1
             raise tool_429
 
@@ -174,7 +176,7 @@ class TestPhase1CurrentBehavior(unittest.TestCase):
         )
         call_count = [0]
 
-        def func(data, metadata):
+        def func(data, metadata, timeout=None):
             call_count[0] += 1
             raise tool_401
 
@@ -198,7 +200,7 @@ class TestPhase1CurrentBehavior(unittest.TestCase):
         scalekit_429 = _make_rpc_error(StatusCode.RESOURCE_EXHAUSTED)  # no error_code
         call_count = [0]
 
-        def func(data, metadata):
+        def func(data, metadata, timeout=None):
             call_count[0] += 1
             raise scalekit_429
 
@@ -222,7 +224,7 @@ class TestPhase2NewBehavior(unittest.TestCase):
     def _always_raise(self, exc):
         call_count = [0]
 
-        def func(data, metadata):
+        def func(data, metadata, timeout=None):
             call_count[0] += 1
             raise exc
 
@@ -407,7 +409,7 @@ class TestPhase2NewBehavior(unittest.TestCase):
         success_response = object()
         call_count = [0]
 
-        def func(data, metadata):
+        def func(data, metadata, timeout=None):
             call_count[0] += 1
             if call_count[0] == 1:
                 raise unauth_error
@@ -427,7 +429,7 @@ class TestPhase2NewBehavior(unittest.TestCase):
         scalekit_429 = _make_rpc_error(StatusCode.RESOURCE_EXHAUSTED)  # no error_code
         call_count = [0]
 
-        def func(data, metadata):
+        def func(data, metadata, timeout=None):
             call_count[0] += 1
             raise scalekit_429
 

--- a/tests/test_tool_timeout.py
+++ b/tests/test_tool_timeout.py
@@ -1,0 +1,192 @@
+"""
+Tool-execution RPCs (ToolsClient, ActionClient.request) proxy to third-party
+provider APIs (Google Calendar, Slack, etc.) and can legitimately run longer
+than typical control-plane calls. They must use their own tool_timeout_ms
+deadline instead of the tighter control-plane timeout_ms, so a slow (but
+healthy) provider call isn't killed early. Also verifies the gRPC channel
+now carries a deadline at all (previously calls could hang forever on a
+silently dropped connection), and that UNAVAILABLE retries back off.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+import grpc
+from grpc import StatusCode
+
+from scalekit.core import CoreClient, DEFAULT_TIMEOUT_MS, DEFAULT_TOOL_TIMEOUT_MS
+from scalekit.client import ScalekitClient
+from scalekit.tools import ToolsClient
+from scalekit.actions.actions import ActionClient
+
+
+def _make_rpc_error(status_code: StatusCode, message: str = "error"):
+    class _FakeRpcError(grpc.RpcError):
+        def code(self):
+            return status_code
+
+        def trailing_metadata(self):
+            return ()
+
+        def details(self):
+            return message
+
+    return _FakeRpcError()
+
+
+def _make_core_client(timeout_ms=None, tool_timeout_ms=None):
+    """Return a CoreClient instance with __init__ bypassed (no real network calls)."""
+    client = CoreClient.__new__(CoreClient)
+    client.access_token = "test-token"
+    client.host = "example.com"
+    client.env_url = "https://example.com"
+    client.client_id = "cid"
+    client.client_secret = "csec"
+    client.keys = {}
+    client.grpc_secure_channel = None
+    client.timeout_ms = timeout_ms if timeout_ms is not None else DEFAULT_TIMEOUT_MS
+    client.tool_timeout_ms = tool_timeout_ms if tool_timeout_ms is not None else DEFAULT_TOOL_TIMEOUT_MS
+    return client
+
+
+class _FakeChannel:
+    """Minimal grpc.Channel stand-in: unary_unary() just returns a MagicMock,
+    so stub.SomeMethod.with_call is itself a MagicMock we can assert on."""
+
+    def unary_unary(self, *args, **kwargs):
+        return MagicMock()
+
+
+class TestCoreClientTimeoutDefaults(unittest.TestCase):
+    def test_defaults(self):
+        self.assertEqual(DEFAULT_TIMEOUT_MS, 20_000)
+        self.assertEqual(DEFAULT_TOOL_TIMEOUT_MS, 60_000)
+
+    @patch.object(CoreClient, "_CoreClient__authenticate_client", lambda self: None)
+    @patch.object(
+        CoreClient,
+        "_CoreClient__grpc_secure_channel",
+        lambda self: setattr(self, "grpc_secure_channel", _FakeChannel()),
+    )
+    def test_scalekit_client_honors_custom_tool_timeout_ms(self):
+        client = ScalekitClient(
+            "https://example.scalekit.dev", "cid", "csec", tool_timeout_ms=45_000
+        )
+        self.assertEqual(client.core_client.tool_timeout_ms, 45_000)
+        self.assertEqual(client.core_client.timeout_ms, DEFAULT_TIMEOUT_MS)
+
+    @patch.object(CoreClient, "_CoreClient__authenticate_client", lambda self: None)
+    @patch.object(
+        CoreClient,
+        "_CoreClient__grpc_secure_channel",
+        lambda self: setattr(self, "grpc_secure_channel", _FakeChannel()),
+    )
+    def test_scalekit_client_defaults_when_unconfigured(self):
+        client = ScalekitClient("https://example.scalekit.dev", "cid", "csec")
+        self.assertEqual(client.core_client.timeout_ms, DEFAULT_TIMEOUT_MS)
+        self.assertEqual(client.core_client.tool_timeout_ms, DEFAULT_TOOL_TIMEOUT_MS)
+
+
+class TestGrpcExecTimeoutWiring(unittest.TestCase):
+    def setUp(self):
+        self.client = _make_core_client(timeout_ms=20_000, tool_timeout_ms=45_000)
+
+    def test_default_call_uses_control_plane_timeout_in_seconds(self):
+        func = MagicMock(return_value="ok")
+        result = self.client.grpc_exec(func, data=None)
+        self.assertEqual(result, "ok")
+        _, kwargs = func.call_args
+        self.assertEqual(kwargs["timeout"], 20.0)
+
+    def test_explicit_timeout_ms_overrides_control_plane_default(self):
+        func = MagicMock(return_value="ok")
+        self.client.grpc_exec(func, data=None, timeout_ms=45_000)
+        _, kwargs = func.call_args
+        self.assertEqual(kwargs["timeout"], 45.0)
+
+    def test_timeout_ms_preserved_across_unauthenticated_retry(self):
+        calls = iter([_make_rpc_error(StatusCode.UNAUTHENTICATED), "ok"])
+
+        def func(data, metadata, timeout=None):
+            effect = next(calls)
+            if isinstance(effect, Exception):
+                raise effect
+            return effect
+
+        with patch.object(self.client, "_CoreClient__authenticate_client"):
+            result = self.client.grpc_exec(func, data=None, retry=2, timeout_ms=45_000)
+
+        self.assertEqual(result, "ok")
+
+    def test_unavailable_retries_with_backoff_and_preserves_timeout(self):
+        calls = iter([_make_rpc_error(StatusCode.UNAVAILABLE), "ok"])
+
+        def func(data, metadata, timeout=None):
+            effect = next(calls)
+            if isinstance(effect, Exception):
+                raise effect
+            self.assertEqual(timeout, 45.0)
+            return effect
+
+        with patch("scalekit.core.time.sleep") as mock_sleep:
+            result = self.client.grpc_exec(func, data=None, retry=2, timeout_ms=45_000)
+
+        self.assertEqual(result, "ok")
+        mock_sleep.assert_called_once()
+
+
+class TestToolsClientUsesToolTimeout(unittest.TestCase):
+    def setUp(self):
+        self.core_client = _make_core_client(timeout_ms=20_000, tool_timeout_ms=45_000)
+        self.core_client.grpc_secure_channel = _FakeChannel()
+        self.tools = ToolsClient(self.core_client)
+
+    def test_list_tools_uses_tool_timeout(self):
+        self.tools.tool_service.ListTools.with_call.return_value = "ok"
+        self.tools.list_tools(page_size=10)
+        _, kwargs = self.tools.tool_service.ListTools.with_call.call_args
+        self.assertEqual(kwargs["timeout"], 45.0)
+
+    def test_list_scoped_tools_uses_tool_timeout(self):
+        self.tools.tool_service.ListScopedTools.with_call.return_value = "ok"
+        self.tools.list_scoped_tools(identifier="id")
+        _, kwargs = self.tools.tool_service.ListScopedTools.with_call.call_args
+        self.assertEqual(kwargs["timeout"], 45.0)
+
+    def test_execute_tool_uses_tool_timeout(self):
+        self.tools.tool_service.ExecuteTool.with_call.return_value = "ok"
+        self.tools.execute_tool(tool_name="gmail_send_email", identifier="id")
+        _, kwargs = self.tools.tool_service.ExecuteTool.with_call.call_args
+        self.assertEqual(kwargs["timeout"], 45.0)
+
+
+class TestActionClientRequestProxyTimeout(unittest.TestCase):
+    def setUp(self):
+        self.core_client = _make_core_client(timeout_ms=20_000, tool_timeout_ms=45_000)
+        self.core_client.grpc_secure_channel = _FakeChannel()
+        self.tools = ToolsClient(self.core_client)
+        self.actions = ActionClient(self.tools, connected_accounts_client=None)
+
+    def test_defaults_to_tool_timeout_ms(self):
+        with patch("scalekit.actions.actions.requests.request") as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            self.actions.request(
+                connection_name="slack", identifier="user@example.com", path="/chat.postMessage"
+            )
+        _, kwargs = mock_request.call_args
+        self.assertEqual(kwargs["timeout"], 45.0)
+
+    def test_per_call_override(self):
+        with patch("scalekit.actions.actions.requests.request") as mock_request:
+            mock_request.return_value = MagicMock(status_code=200)
+            self.actions.request(
+                connection_name="slack",
+                identifier="user@example.com",
+                path="/chat.postMessage",
+                timeout=5,
+            )
+        _, kwargs = mock_request.call_args
+        self.assertEqual(kwargs["timeout"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes SK-1210: no client-side gRPC deadline was configured anywhere, so a silently-dropped connection (the Rember network-dropoff case) hung forever with no error to retry on.
- Adds `timeout_ms` (default 20s) for control-plane RPCs and a separate `tool_timeout_ms` (default 60s) for tool-execution RPCs (`ToolsClient`, `ActionClient.execute_tool`, `ActionClient.request` REST proxy) since those proxy to third-party APIs and can legitimately run longer than a control-plane call.
- `UNAVAILABLE` retries now back off exponentially (base 1s, doubling, capped at 30s, jittered) instead of being caught by the pre-existing blind zero-backoff retry.
- `ActionClient.request`'s REST proxy default timeout is unified onto `tool_timeout_ms` instead of a separate hardcoded `30s`.

## Behavior change (flagged, not silent)
This adds a default deadline where none existed before. Any customer whose control-plane call legitimately takes longer than 20s will now get a clean `DeadlineExceeded`-based `ScalekitServerException` after upgrading, instead of eventually succeeding. Recommend treating this as a **minor** version bump with a CHANGELOG callout, not a patch. Version bumped 2.13.0 → 2.14.0.

## Test plan
- [x] New unit suite `tests/test_tool_timeout.py` (12 tests, mock-based): timeout defaults, `ScalekitClient` constructor wiring, `grpc_exec` timeout/backoff plumbing, `ToolsClient` and `ActionClient.request` both use `tool_timeout_ms`.
- [x] `tests/test_sk819_retry_behavior.py` (21 tests) still pass unmodified behavior for TOOL_ERROR/RESOURCE_EXHAUSTED/UNAUTHENTICATED paths.
- [x] Live integration test against a real environment with a configured Gmail connection: `tools.list_tools`, `tools.execute_tool("gmail_get_profile")`, and `actions.request(.../profile)` (REST proxy) all succeed end-to-end with the new deadlines wired in.
- [x] `tests/test_tools.py` and `tests/test_actions.py` run against a live env — identical pass/fail split with and without this change (remaining failures are pre-existing missing test fixtures in that env, confirmed by running the same suite on unmodified `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeouts for control-plane and tool-execution requests.
  * Added per-request timeout overrides for action requests.
  * Tool operations now use the configured tool timeout.

* **Bug Fixes**
  * Improved retry handling for temporarily unavailable services with exponential backoff and jitter.
  * Preserved timeout settings when retrying after authentication refreshes.

* **Chores**
  * Updated the SDK version to 2.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->