### PR TITLE
[SK-1268] - fix(tests): update role uniqueness test for AlreadyExists error code

### DIFF
--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,6 +1,6 @@
 from faker import Faker
 
-from scalekit.common.exceptions import ScalekitBadRequestException, ScalekitNotFoundException, ScalekitException
+from scalekit.common.exceptions import ScalekitBadRequestException, ScalekitConflictException, ScalekitNotFoundException, ScalekitException
 from tests.basetest import BaseTest
 
 from scalekit.v1.roles.roles_pb2 import CreateRole, UpdateRole
@@ -305,9 +305,9 @@ class TestRoles(BaseTest):
         try:
             self.scalekit_client.roles.create_role(role=role2)
             self.fail("Should have failed due to duplicate name")
-        except ScalekitBadRequestException as exp:
+        except ScalekitConflictException as exp:
             # Expected behavior - duplicate name error
-            self.assertTrue(exp.message, 'duplicate key not allowed')
+            self.assertEqual(exp.error_code, "ROLE_KEYNAME_CONFLICT")
 
     def test_delete_role_base(self):
         """ Method to test deleting the base inheritance relationship for an environment-level role """


### PR DESCRIPTION
## Summary
- scalekit-inc/scalekit#2393 changed duplicate role-key creation (`CreateRole`) to return gRPC `AlreadyExists` with error code `ROLE_KEYNAME_CONFLICT` instead of `InvalidArgument` with the message `"duplicate key not allowed"`.
- This broke `test_role_name_uniqueness` in `tests/test_roles.py`, which caught `ScalekitBadRequestException` — the SDK maps `AlreadyExists` to `ScalekitConflictException`, so the test would fail with an unhandled exception.
- Updated the test to catch `ScalekitConflictException` and assert on the new `ROLE_KEYNAME_CONFLICT` error code.

Test-only change — no SDK source was modified. Swept roles-related tests in scalekit-sdk-node, scalekit-sdk-go, scalekit-sdk-java, scalekit-sdk-dotnet, and scalekit-sdk-python-lite as well; none of them assert on the specific status/message for this path, so only this one test needed a fix.

## Test plan
- [ ] `python3 -m py_compile tests/test_roles.py` passes
- [ ] `test_role_name_uniqueness` passes against a server running scalekit-inc/scalekit#2393

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated role name uniqueness coverage to validate the conflict error type and error code returned for duplicate role names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->