### PR TITLE
[SK-1276] Bump SDK version to 2.14.0 and API version to 20260716

### DIFF
--- a/scalekit/_version.py
+++ b/scalekit/_version.py
@@ -1,3 +1,3 @@
 # Single source of truth for the SDK version.
 # Import this in setup.py and scalekit/core.py — never hardcode the version elsewhere.
-__version__ = "2.13.0"
+__version__ = "2.14.0"

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -29,7 +29,7 @@ class CoreClient:
 
     sdk_version = f"Scalekit-Python/{_sdk_version}"
     # YYYYMMDD
-    api_version = "20260603"
+    api_version = "20260716"
     user_agent = f"{sdk_version} Python/{platform.python_version()} ({platform.system()}; {platform.architecture()}"
 
     def __init__(self, env_url, client_id, client_secret):


### PR DESCRIPTION
## Summary

- Bump SDK version from `2.13.0` to `2.14.0` (minor bump — last PR added new features: NO_AUTH auth type, `icon_src`/`metadata` on Provider, `auth_header_key_override`, Token Template RPCs)
- Update `api_version` in `core.py` from `20260603` to `20260716`

## Test plan

- [ ] Verify `scalekit.__version__` returns `2.14.0`
- [ ] Verify `x-api-version` header sent in gRPC requests is `20260716`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDK to version 2.14.0.
  * Updated the API version used for subsequent requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->