### PR TITLE
fix: detect camelCase param keys in execute_tool and raise helpful error

### DIFF
--- a/scalekit/tools.py
+++ b/scalekit/tools.py
@@ -7,6 +7,9 @@ from scalekit.v1.tools.tools_pb2_grpc import ToolServiceStub
 from google.protobuf import empty_pb2
 
 
+_SNAKE_CASE_RE = re.compile(r'^[a-z][a-z0-9]*(_[a-z0-9]+)*$')
+
+
 def _camel_to_snake(name: str) -> str:
     """Convert a camelCase string to snake_case."""
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
@@ -125,12 +128,21 @@ class ToolsClient:
 
         params_struct = None
         if params:
-            camel_keys = {k: _camel_to_snake(k) for k in params if _camel_to_snake(k) != k}
-            if camel_keys:
-                hints = [f"'{snake}' (you passed '{camel}')" for camel, snake in camel_keys.items()]
+            invalid = {}
+            for k in params:
+                if not _SNAKE_CASE_RE.match(k):
+                    suggestion = _camel_to_snake(k)
+                    invalid[k] = suggestion if suggestion != k else None
+            if invalid:
+                hints = []
+                for key, suggestion in invalid.items():
+                    if suggestion:
+                        hints.append(f"'{suggestion}' (you passed '{key}')")
+                    else:
+                        hints.append(f"'{key}' is not valid snake_case")
                 raise ValueError(
                     f"Tool input keys must be snake_case. "
-                    f"Did you mean: {', '.join(hints)}? "
+                    f"Invalid keys: {', '.join(hints)}. "
                     f"Tool input keys must match the snake_case schema shown for this tool."
                 )
             params_struct = struct_pb2.Struct()

--- a/scalekit/tools.py
+++ b/scalekit/tools.py
@@ -1,9 +1,16 @@
+import re
 from typing import Optional
 
 from scalekit.core import CoreClient
 from scalekit.v1.tools.tools_pb2 import *
 from scalekit.v1.tools.tools_pb2_grpc import ToolServiceStub
 from google.protobuf import empty_pb2
+
+
+def _camel_to_snake(name: str) -> str:
+    """Convert a camelCase string to snake_case."""
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
 
 class ToolsClient:
@@ -118,6 +125,14 @@ class ToolsClient:
 
         params_struct = None
         if params:
+            camel_keys = {k: _camel_to_snake(k) for k in params if _camel_to_snake(k) != k}
+            if camel_keys:
+                hints = [f"'{snake}' (you passed '{camel}')" for camel, snake in camel_keys.items()]
+                raise ValueError(
+                    f"Tool input keys must be snake_case. "
+                    f"Did you mean: {', '.join(hints)}? "
+                    f"Tool input keys must match the snake_case schema shown for this tool."
+                )
             params_struct = struct_pb2.Struct()
             params_struct.update(params)
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                     
  - `execute_tool` previously forwarded camelCase keys (e.g. `{"threadId": "abc123"}`) directly to the API, which returned a cryptic error like `input.thread_id is missing` — giving no hint that the key name itself was wrong.                                      
  - Added a `_camel_to_snake` helper and a pre-flight validation step in `execute_tool` that detects camelCase keys **before** making the gRPC call and raises a clear `ValueError` with the exact fix needed.                                                       
                                                                                                                                                                                                                                                                       
  ## Error before this fix                                                                                                                                                                                                                                           

  ScalekitBadRequestException: input.thread_id is missing

  ## Error after this fix

  ValueError: Tool input keys must be snake_case.
  Did you mean: 'thread_id' (you passed 'threadId')?
  Tool input keys must match the snake_case schema shown for this tool.

  ## Changes

  - `scalekit/tools.py` — added `_camel_to_snake()` helper and camelCase key validation in `execute_tool`

  ## Test plan

  - [x] Pass a camelCase key like `{"threadId": "123"}` to `execute_tool` and confirm the new `ValueError` is raised with the correct hint
  - [x] Pass valid snake_case keys and confirm normal execution is unaffected
  - [x] Confirm mixed params (some camelCase, some snake_case) surface all offending keys in the error message

  Fixes #151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for tool input keys to ensure they use the required snake_case format.
  * Improved error messages with suggestions when camelCase keys are detected.
  * Prevented tool execution when input keys do not match the expected schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->