### PR TITLE
fix: default page_size to 100 and warn on truncation in get_tools

### DIFF
--- a/scalekit/actions/frameworks/google_adk.py
+++ b/scalekit/actions/frameworks/google_adk.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional, Any, Dict, List, Callable
 from scalekit.tools import ToolsClient
 from scalekit.v1.tools.tools_pb2 import Filter, ScopedToolFilter
@@ -22,24 +23,23 @@ class GoogleADK:
         providers: Optional[List[str]] = None,
         tool_names: Optional[List[str]] = None,
         connection_names: Optional[List[str]] = None,
-        page_size: Optional[int] = None,
+        page_size: int = 100,
         page_token: Optional[str] = None
     ) -> List[ScalekitGoogleAdkTool]:
         """
         Get scoped tools from Scalekit and convert them to Google ADK compatible tools
-        
+
         :param identifier: Identifier to scope the tools list
         :param providers: List of provider names to filter by
         :param tool_names: List of tool names to filter by
         :param connection_names: List of connection names to filter by
-        :param page_size: Maximum number of tools to return per page  
+        :param page_size: Maximum number of tools to return per page (default: 100)
         :param page_token: Token from a previous response for pagination
         :returns: List of Google ADK compatible tools
         :raises ImportError: If Google ADK dependencies are not installed
         """
         if identifier is None or identifier == "":
             raise ValueError("Identifier must be provided to get tools")
-
 
         # Create ScopedToolFilter if any filter parameters are provided
         scoped_filter = None
@@ -52,10 +52,19 @@ class GoogleADK:
 
         # Call list_scoped_tools which returns (response, metadata) tuple
         result_tuple = self.tools.list_scoped_tools(identifier, scoped_filter, page_size, page_token)
-        
+
         # Extract the response[0] (the actual ListScopedToolsResponse proto object)
         response = result_tuple[0]
-        
+
+        if response.next_page_token:
+            warnings.warn(
+                f"get_tools() returned {len(response.tools)} of {response.total_size} available tools. "
+                f"More tools exist — pass page_token='{response.next_page_token}' to fetch the next page, "
+                f"or use list_scoped_tools() directly for full pagination control.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         google_adk_tools = []
         for scoped_tool in response.tools:
             google_adk_tool = self._convert_tool_to_google_adk_tool(
@@ -63,7 +72,7 @@ class GoogleADK:
                 scoped_tool.connected_account_id
             )
             google_adk_tools.append(google_adk_tool)
-            
+
         return google_adk_tools
     
     def _convert_tool_to_google_adk_tool(self, tool, connected_account_id: str):

--- a/scalekit/actions/frameworks/langchain.py
+++ b/scalekit/actions/frameworks/langchain.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional, Any, Dict, List, Callable
 from langchain_core.tools import StructuredTool
 from scalekit.tools import ToolsClient
@@ -19,17 +20,17 @@ class LangChain:
         providers: Optional[List[str]] = None,
         tool_names: Optional[List[str]] = None,
         connection_names: Optional[List[str]] = None,
-        page_size: Optional[int] = None,
+        page_size: int = 100,
         page_token: Optional[str] = None
     ) -> List[StructuredTool]:
         """
         Get scoped tools from Scalekit and convert them to LangChain StructuredTools
-        
+
         :param identifier: Identifier to scope the tools list
         :param providers: List of provider names to filter by
         :param tool_names: List of tool names to filter by
         :param connection_names: List of connection names to filter by
-        :param page_size: Maximum number of tools to return per page  
+        :param page_size: Maximum number of tools to return per page (default: 100)
         :param page_token: Token from a previous response for pagination
         :returns: List of LangChain StructuredTools
         """
@@ -47,10 +48,19 @@ class LangChain:
 
         # Call list_scoped_tools which returns (response, metadata) tuple
         result_tuple = self.tools.list_scoped_tools(identifier, scoped_filter, page_size, page_token)
-        
+
         # Extract the response[0] (the actual ListScopedToolsResponse proto object)
         response = result_tuple[0]
-        
+
+        if response.next_page_token:
+            warnings.warn(
+                f"get_tools() returned {len(response.tools)} of {response.total_size} available tools. "
+                f"More tools exist — pass page_token='{response.next_page_token}' to fetch the next page, "
+                f"or use list_scoped_tools() directly for full pagination control.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         structured_tools = []
         for scoped_tool in response.tools:
             structured_tool = self._convert_tool_to_structured_tool(
@@ -58,7 +68,7 @@ class LangChain:
                 scoped_tool.connected_account_id
             )
             structured_tools.append(structured_tool)
-            
+
         return structured_tools
     
     def _convert_tool_to_structured_tool(self, tool, connected_account_id: str) -> StructuredTool:


### PR DESCRIPTION
 ## Summary

  - `get_tools()` in both `LangChain` and `GoogleADK` helpers defaulted to `page_size=None`, which silently fell back to the service default of 10 tools — causing connectors with more tools (e.g. Slack, Gmail) to appear incomplete with no signal to the developer.
  - Changed the default to `page_size=100` so most connectors are fully covered out of the box.
  - Added a `UserWarning` when the response includes a `next_page_token`, telling the developer exactly how many tools were returned vs. available, and providing the token to fetch the next page.

  ## Warning example (when results are still truncated)

  UserWarning: get_tools() returned 100 of 143 available tools.
  More tools exist — pass page_token='eyJwYWdl...' to fetch the next page,
  or use list_scoped_tools() directly for full pagination control.

  ## Changes

  - `scalekit/actions/frameworks/langchain.py` — `page_size` default `None` → `100`, added truncation warning
  - `scalekit/actions/frameworks/google_adk.py` — same changes

  ## Test plan

  - [ ] Call `get_tools()` with no `page_size` argument and confirm it fetches up to 100 tools
  - [ ] Mock a response with `next_page_token` set and confirm the `UserWarning` is emitted with correct counts and token
  - [ ] Confirm no warning is emitted when all tools fit in one page

  Fixes #150
