### PR TITLE
Add AuditLogs and Events SDK wrappers

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6768,3 +6768,284 @@ scalekit_client.actions.providers.delete_custom_provider(
 </dd>
 </dl>
 </details>
+
+## Events
+
+<details><summary><code>scalekit_client.events.<a href="https://github.com/scalekit-inc/scalekit-sdk-python/blob/main/scalekit/events.py">list_events</a>(event_types?, start_time?, end_time?, organization_id?, source?, auth_request_id?, interceptor_id?, interceptor_status?, interceptor_decision?, connection_id?, connected_account_id?, page_size?, page_token?) -> ListEventsResponse</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+Lists events for the current environment, ordered most-recent first, including a total count of matching events. Pass `auth_request_id` to see every event a specific authentication request produced — correlate it with the `auth_request_id` returned by `AuditLogsClient.list_auth_requests`.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+response = scalekit_client.events.list_events(
+    auth_request_id='areq_123456',
+    page_size=10
+)
+
+print(f'Found {response[0].total_size} events')
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**event_types:** `Optional[List[str]]` - Filter by one or more event type names
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**start_time:** `Optional[google.protobuf.Timestamp]` - Only return events at or after this timestamp
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**end_time:** `Optional[google.protobuf.Timestamp]` - Only return events at or before this timestamp
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**organization_id:** `Optional[str]` - Filter by organization ID
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**source:** `Optional[str | int]` - Filter by event source ("SCALEKIT" or "DIR_SYNC")
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**auth_request_id:** `Optional[str]` - Filter by the authentication request that produced the events
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**interceptor_id:** `Optional[str]` - Filter by interceptor ID
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**interceptor_status:** `Optional[str]` - Filter by interceptor status
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**interceptor_decision:** `Optional[str]` - Filter by interceptor decision
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**connection_id:** `Optional[str]` - Filter by connection ID
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**connected_account_id:** `Optional[str]` - Filter by connected account ID
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**page_size:** `Optional[int]` - Number of events to return per page
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**page_token:** `Optional[str]` - Opaque pagination cursor from a previous response
+
+</dd>
+</dl>
+</dd>
+</dl>
+
+</dd>
+</dl>
+</details>
+
+## Audit Logs
+
+<details><summary><code>scalekit_client.audit_logs.<a href="https://github.com/scalekit-inc/scalekit-sdk-python/blob/main/scalekit/audit_logs.py">list_auth_requests</a>(page_size?, page_token?, email?, status?, start_time?, end_time?, resource_id?, connected_account_identifier?, client_id?) -> ListAuthLogResponse</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+Lists authentication request logs for the current environment, ordered most-recent first. Each entry's `auth_request_id` can be passed to `EventsClient.list_events`'s `auth_request_id` filter to see every event a specific login produced.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```python
+response = scalekit_client.audit_logs.list_auth_requests(
+    email='jane.doe@example.com',
+    page_size=10
+)
+
+for entry in response[0].authRequests:
+    print(f'Auth request: {entry.auth_request_id} - {entry.status}')
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**page_size:** `Optional[int]` - Number of authentication request logs to return per page
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**page_token:** `Optional[str]` - Opaque pagination cursor from a previous response
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**email:** `Optional[str]` - Filter by the end user's email address
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**status:** `Optional[List[str]]` - Filter by one or more outcome statuses (e.g. "SUCCESS", "FAILED")
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**start_time:** `Optional[google.protobuf.Timestamp]` - Only return authentication logs at or after this timestamp
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**end_time:** `Optional[google.protobuf.Timestamp]` - Only return authentication logs at or before this timestamp
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**resource_id:** `Optional[str]` - Filter by resource ID
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**connected_account_identifier:** `Optional[str]` - Filter by connected account identifier
+
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**client_id:** `Optional[str]` - Filter by client ID
+
+</dd>
+</dl>
+</dd>
+</dl>
+
+</dd>
+</dl>
+</details>

--- a/scalekit/audit_logs.py
+++ b/scalekit/audit_logs.py
@@ -1,0 +1,87 @@
+from typing import List, Optional
+
+from scalekit.core import CoreClient
+from scalekit.v1.auditlogs.auditlogs_pb2 import (
+    ListAuthLogRequest,
+    ListAuthLogResponse,
+)
+from scalekit.v1.auditlogs.auditlogs_pb2_grpc import AuditLogsServiceStub
+
+
+class AuditLogsClient:
+    """Class definition for Audit Logs Client"""
+
+    def __init__(self, core_client: CoreClient):
+        """
+        Initializer for Audit Logs Client
+
+        :param core_client    : CoreClient Object
+        :type                 : ``` obj ```
+        :returns
+            None
+        """
+        self.core_client = core_client
+        self.audit_logs_service = AuditLogsServiceStub(
+            self.core_client.grpc_secure_channel
+        )
+
+    def list_auth_requests(
+        self,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+        email: Optional[str] = None,
+        status: Optional[List[str]] = None,
+        start_time=None,
+        end_time=None,
+        resource_id: Optional[str] = None,
+        connected_account_identifier: Optional[str] = None,
+        client_id: Optional[str] = None,
+    ) -> ListAuthLogResponse:
+        """
+        Method to list authentication request logs for the current environment, ordered
+        most-recent first.
+
+        :param page_size                     : Number of authentication request logs to
+                                                return per page
+        :type                                 : ``` int ```
+        :param page_token                     : Opaque pagination cursor from a previous
+                                                response
+        :type                                 : ``` str ```
+        :param email                          : Filter by the end user's email address
+        :type                                 : ``` str ```
+        :param status                         : Filter by one or more outcome statuses
+                                                (e.g. "SUCCESS", "FAILED")
+        :type                                 : ``` List[str] ```
+        :param start_time                     : Only return authentication logs at or after
+                                                this timestamp
+        :type                                 : ``` google.protobuf.Timestamp ```
+        :param end_time                       : Only return authentication logs at or before
+                                                this timestamp
+        :type                                 : ``` google.protobuf.Timestamp ```
+        :param resource_id                    : Filter by resource ID
+        :type                                 : ``` str ```
+        :param connected_account_identifier   : Filter by connected account identifier
+        :type                                 : ``` str ```
+        :param client_id                      : Filter by client ID
+        :type                                 : ``` str ```
+
+        :returns:
+            List Auth Log Response. Each entry's auth_request_id can be passed to
+            EventsClient.list_events(auth_request_id=...) to see every event a specific
+            login produced.
+        """
+        request = ListAuthLogRequest(
+            page_size=page_size,
+            page_token=page_token,
+            email=email,
+            start_time=start_time,
+            end_time=end_time,
+            resource_id=resource_id,
+            connected_account_identifier=connected_account_identifier,
+            client_id=client_id,
+        )
+        if status:
+            request.status.extend(status)
+        return self.core_client.grpc_exec(
+            self.audit_logs_service.ListAuthRequests.with_call, request
+        )

--- a/scalekit/client.py
+++ b/scalekit/client.py
@@ -28,6 +28,8 @@ from scalekit.sessions import SessionsClient
 from scalekit.auth import AuthClient
 from scalekit.webauthn import WebAuthnClient
 from scalekit.token import TokenClient
+from scalekit.events import EventsClient
+from scalekit.audit_logs import AuditLogsClient
 from scalekit.common.scalekit import (
     AuthorizationUrlOptions,
     CodeAuthenticationOptions,
@@ -85,6 +87,8 @@ class ScalekitClient:
             self.auth = AuthClient(self.core_client)
             self.webauthn = WebAuthnClient(self.core_client)
             self.tokens = TokenClient(self.core_client)
+            self.events = EventsClient(self.core_client)
+            self.audit_logs = AuditLogsClient(self.core_client)
         except Exception:
             raise
 

--- a/scalekit/events.py
+++ b/scalekit/events.py
@@ -1,0 +1,104 @@
+from typing import List, Optional, Union
+
+from scalekit.core import CoreClient
+from scalekit.v1.events.events_pb2 import (
+    EventFilter,
+    ListEventsRequest,
+    ListEventsResponse,
+    Source,
+)
+from scalekit.v1.events.events_pb2_grpc import EventsServiceStub
+
+
+class EventsClient:
+    """Class definition for Events Client"""
+
+    def __init__(self, core_client: CoreClient):
+        """
+        Initializer for Events Client
+
+        :param core_client    : CoreClient Object
+        :type                 : ``` obj ```
+        :returns
+            None
+        """
+        self.core_client = core_client
+        self.events_service = EventsServiceStub(self.core_client.grpc_secure_channel)
+
+    def list_events(
+        self,
+        event_types: Optional[List[str]] = None,
+        start_time=None,
+        end_time=None,
+        organization_id: Optional[str] = None,
+        source: Optional[Union[str, int]] = None,
+        auth_request_id: Optional[str] = None,
+        interceptor_id: Optional[str] = None,
+        interceptor_status: Optional[str] = None,
+        interceptor_decision: Optional[str] = None,
+        connection_id: Optional[str] = None,
+        connected_account_id: Optional[str] = None,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+    ) -> ListEventsResponse:
+        """
+        Method to list events for the current environment, ordered most-recent first.
+
+        :param event_types            : Filter by one or more event type names
+        :type                         : ``` List[str] ```
+        :param start_time             : Only return events at or after this timestamp
+        :type                         : ``` google.protobuf.Timestamp ```
+        :param end_time               : Only return events at or before this timestamp
+        :type                         : ``` google.protobuf.Timestamp ```
+        :param organization_id        : Filter by organization ID
+        :type                         : ``` str ```
+        :param source                 : Filter by event source ("SCALEKIT" or "DIR_SYNC")
+        :type                         : ``` str | int ```
+        :param auth_request_id        : Filter by the authentication request that produced the
+                                        events. Correlate with a value returned by
+                                        AuditLogsClient.list_auth_requests()'s auth_request_id field.
+        :type                         : ``` str ```
+        :param interceptor_id         : Filter by interceptor ID
+        :type                         : ``` str ```
+        :param interceptor_status     : Filter by interceptor status
+        :type                         : ``` str ```
+        :param interceptor_decision   : Filter by interceptor decision
+        :type                         : ``` str ```
+        :param connection_id          : Filter by connection ID
+        :type                         : ``` str ```
+        :param connected_account_id   : Filter by connected account ID
+        :type                         : ``` str ```
+        :param page_size              : Number of events to return per page
+        :type                         : ``` int ```
+        :param page_token             : Opaque pagination cursor from a previous response
+        :type                         : ``` str ```
+
+        :returns:
+            List Events Response
+        """
+        event_filter = EventFilter(
+            organization_id=organization_id,
+            auth_request_id=auth_request_id,
+            interceptor_id=interceptor_id,
+            interceptor_status=interceptor_status,
+            interceptor_decision=interceptor_decision,
+            connection_id=connection_id,
+            connected_account_id=connected_account_id,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        if event_types:
+            event_filter.event_types.extend(event_types)
+        if source is not None:
+            event_filter.source = (
+                Source.Value(source) if isinstance(source, str) else source
+            )
+
+        request = ListEventsRequest(
+            filter=event_filter,
+            page_size=page_size,
+            page_token=page_token,
+        )
+        return self.core_client.grpc_exec(
+            self.events_service.ListEvents.with_call, request
+        )

--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -1,4 +1,5 @@
 from basetest import BaseTest
+from scalekit.common.exceptions import ScalekitServerException
 
 
 class TestAuditLogs(BaseTest):
@@ -26,13 +27,18 @@ class TestAuditLogs(BaseTest):
 
     def test_list_auth_requests_pagination_token_is_client_validated_string(self):
         """page_token accepts a string cursor; a malformed one is rejected by the server, not swallowed."""
-        response = self.scalekit_client.audit_logs.list_auth_requests(
-            page_token="not-a-real-cursor"
-        )
-        # The server may reject a malformed cursor (INVALID_ARGUMENT) rather than the SDK
-        # silently ignoring it. Either an explicit rejection or a clean empty page is
-        # acceptable here — what's not acceptable is the SDK eating the parameter.
-        self.assertIn(response[1].code().name, ("OK", "INVALID_ARGUMENT"))
+        # grpc_exec re-raises a malformed-cursor rejection (INVALID_ARGUMENT) as
+        # ScalekitServerException rather than returning an error-code response tuple — see
+        # GUIDELINES.md: "grpc_exec swallows grpc.RpcError — catch ScalekitServerException
+        # instead." Either an explicit rejection or a clean empty page is acceptable here —
+        # what's not acceptable is the SDK silently ignoring the parameter.
+        try:
+            response = self.scalekit_client.audit_logs.list_auth_requests(
+                page_token="not-a-real-cursor"
+            )
+            self.assertEqual(response[1].code().name, "OK")
+        except ScalekitServerException:
+            pass
 
     def test_events_correlate_with_auth_request_id(self):
         """

--- a/tests/test_audit_logs.py
+++ b/tests/test_audit_logs.py
@@ -1,0 +1,72 @@
+from basetest import BaseTest
+
+
+class TestAuditLogs(BaseTest):
+    """Class definition for Test Audit Logs Class"""
+
+    def test_list_auth_requests_basic(self):
+        """List authentication request logs with no filter returns a valid response shape."""
+        response = self.scalekit_client.audit_logs.list_auth_requests()
+        self.assertEqual(response[1].code().name, "OK")
+        self.assertTrue(response[0] is not None)
+        self.assertTrue(hasattr(response[0], "authRequests"))
+        self.assertTrue(hasattr(response[0], "total_size"))
+
+    def test_list_auth_requests_with_filters(self):
+        """List authentication request logs accepts email, status, and pagination filters."""
+        response = self.scalekit_client.audit_logs.list_auth_requests(
+            email="nobody-matching@example.com",
+            status=["SUCCESS"],
+            page_size=5,
+        )
+        self.assertEqual(response[1].code().name, "OK")
+        self.assertTrue(response[0] is not None)
+        # A non-matching email filters out all logs, but the call still succeeds.
+        self.assertEqual(len(response[0].authRequests), 0)
+
+    def test_list_auth_requests_pagination_token_is_client_validated_string(self):
+        """page_token accepts a string cursor; a malformed one is rejected by the server, not swallowed."""
+        response = self.scalekit_client.audit_logs.list_auth_requests(
+            page_token="not-a-real-cursor"
+        )
+        # The server may reject a malformed cursor (INVALID_ARGUMENT) rather than the SDK
+        # silently ignoring it. Either an explicit rejection or a clean empty page is
+        # acceptable here — what's not acceptable is the SDK eating the parameter.
+        self.assertIn(response[1].code().name, ("OK", "INVALID_ARGUMENT"))
+
+    def test_events_correlate_with_auth_request_id(self):
+        """
+        Cross-API correlation: fetch real authentication request logs, take a real
+        auth_request_id from the results, then confirm the Events API returns at least
+        one event for that same auth_request_id.
+
+        No IDs are hardcoded — everything is fetched live from the environment. If the
+        environment has no authentication request history, there is nothing to correlate,
+        so the assertion is skipped rather than failed.
+        """
+        auth_requests_response = self.scalekit_client.audit_logs.list_auth_requests(
+            page_size=50
+        )
+        self.assertEqual(auth_requests_response[1].code().name, "OK")
+        auth_requests = auth_requests_response[0].authRequests
+
+        auth_request_id = next(
+            (entry.auth_request_id for entry in auth_requests if entry.auth_request_id),
+            None,
+        )
+        if not auth_request_id:
+            self.skipTest(
+                "No authentication request logs with an auth_request_id were found in "
+                "this environment; nothing to correlate against the Events API."
+            )
+
+        events_response = self.scalekit_client.events.list_events(
+            auth_request_id=auth_request_id
+        )
+        self.assertEqual(events_response[1].code().name, "OK")
+        self.assertGreater(
+            len(events_response[0].events),
+            0,
+            f"Expected at least one event for auth_request_id={auth_request_id!r}, "
+            "which was returned by ListAuthRequests, but the Events API returned none.",
+        )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,45 @@
+from basetest import BaseTest
+
+from scalekit.v1.events.events_pb2 import Source
+
+
+class TestEvents(BaseTest):
+    """Class definition for Test Events Class"""
+
+    def test_list_events_basic(self):
+        """List events with no filter returns a response with events and total_size."""
+        response = self.scalekit_client.events.list_events()
+        self.assertEqual(response[1].code().name, "OK")
+        self.assertTrue(response[0] is not None)
+        self.assertTrue(hasattr(response[0], "events"))
+        self.assertTrue(hasattr(response[0], "total_size"))
+
+    def test_list_events_with_filters(self):
+        """List events accepts organization_id, source, and pagination filters."""
+        response = self.scalekit_client.events.list_events(
+            organization_id="org_does_not_exist",
+            source="SCALEKIT",
+            page_size=5,
+        )
+        self.assertEqual(response[1].code().name, "OK")
+        self.assertTrue(response[0] is not None)
+        # A nonexistent organization_id filters out all events, but the call still succeeds.
+        self.assertEqual(len(response[0].events), 0)
+
+    def test_list_events_with_auth_request_id_filter(self):
+        """Filtering by a well-formed but non-matching auth_request_id returns zero events, not an error."""
+        response = self.scalekit_client.events.list_events(
+            auth_request_id="areq_does_not_exist"
+        )
+        self.assertEqual(response[1].code().name, "OK")
+        self.assertEqual(len(response[0].events), 0)
+
+    def test_list_events_invalid_source_raises_before_network_call(self):
+        """An unrecognized source string is rejected client-side before any gRPC call is made."""
+        with self.assertRaises(ValueError):
+            self.scalekit_client.events.list_events(source="NOT_A_REAL_SOURCE")
+
+    def test_list_events_accepts_enum_source(self):
+        """source also accepts the raw enum value, not just its string name."""
+        response = self.scalekit_client.events.list_events(source=Source.SCALEKIT)
+        self.assertEqual(response[1].code().name, "OK")


### PR DESCRIPTION
## Description

Adds two missing wrapper clients:

- **`scalekit_client.audit_logs.list_auth_requests(...)`** — new client wrapping `AuditLogsService.ListAuthRequests` (`/api/v1/logs/authentication/requests`), newly promoted out of `PREVIEW` in the `scalekit` proto repo (companion PR). No wrapper existed for this service before — only raw generated protobuf stubs.
- **`scalekit_client.events.list_events(...)`** — new client wrapping `EventsService.ListEvents` (the plain, non-paginated `/api/v1/events` RPC), which was completely unwrapped in this SDK (only generated stubs existed). Exposes the full `EventFilter`, including `auth_request_id`.

`list_events(auth_request_id=...)` correlates directly with the `auth_request_id` field returned by `list_auth_requests`, so a caller can look up every event a specific login produced.

REFERENCE.md updated with both new sections.

## Testing

- `pip install -e .` in an isolated venv + smoke import of `ScalekitClient` — both new clients construct and attach correctly (`scalekit_client.events`, `scalekit_client.audit_logs`).
- `python -m py_compile` on all new/changed files — clean.
- New integration tests added (`tests/test_events.py`, `tests/test_audit_logs.py`), following this repo's existing live-environment test pattern (`basetest.py`). **Not run in this session — no live `SCALEKIT_ENV_URL`/`CLIENT_ID`/`CLIENT_SECRET` were available.** They should run in CI, which holds real secrets.
- The cross-API correlation test (`test_events_correlate_with_auth_request_id`) fetches real `auth_request_id` values from `list_auth_requests` at runtime — no IDs are hardcoded — then asserts `list_events(auth_request_id=...)` returns at least one event. It skips (rather than fails) if the environment has no authentication history to correlate against.
- Version bump intentionally **not** included yet — will follow once CI confirms the new tests pass, per team convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015D44Wzgoa1mHMRnAcw4qw6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event listing with filters for type, time range, source, organization, authentication requests, interceptors, connections, accounts, and pagination.
  * Added audit log retrieval with filters for email, status, time range, resources, clients, accounts, and pagination.
  * Exposed Events and Audit Logs through the main client.
* **Documentation**
  * Added comprehensive API reference documentation for both capabilities.
* **Bug Fixes**
  * Added validation for invalid event sources and pagination tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->