### PR TITLE
[SK-111] Add new members as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Avinash-Kamath @jranaskit
+* @Avinash-Kamath @jranaskit @dhawani @srinivaskarre-sk @anujsharmask @AkshayParihar33


### PR DESCRIPTION
## Summary

Adds the following members as code owners in `.github/CODEOWNERS`:

- @dhawani
- @srinivaskarre-sk
- @anujsharmask
- @AkshayParihar33

They are appended to the existing global ownership rule (`*`) alongside the current owners.

## Changes

```
-* @Avinash-Kamath @jranaskit
+* @Avinash-Kamath @jranaskit @dhawani @srinivaskarre-sk @anujsharmask @AkshayParihar33
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRAfH3KH2ffSvsRMCGpDv9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments for broader maintenance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->