### PR TITLE
SK-1504/SK-1505: Native middleware support for (Flask, FastAPI, Django) based Python webapps — v2.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PROTOC_DIR := protoc_gen_openapiv2
 setup: create-venv
 	@echo "Installing SDK dependencies in $(VENV_DIR)..."
 	$(VENV_PIP) install --upgrade pip
-	$(VENV_PIP) install -e .
+	$(VENV_PIP) install -e ".[flask,fastapi,django]"
 
 create-venv:
 	@if [ ! -d "$(VENV_DIR)" ]; then \

--- a/README.md
+++ b/README.md
@@ -155,15 +155,18 @@ pip install scalekit-sdk-python[flask]    # or [fastapi], or [django]
 
 ```python
 # Flask
+import os
 from flask import Flask
 from scalekit.frameworks.flask import ScalekitAuth
 
 app = Flask(__name__)
 auth = ScalekitAuth(
     app,
-    env_url=env_url, client_id=client_id, client_secret=client_secret,
+    env_url=os.environ["SCALEKIT_ENV_URL"],
+    client_id=os.environ["SCALEKIT_CLIENT_ID"],
+    client_secret=os.environ["SCALEKIT_CLIENT_SECRET"],
     redirect_uri="https://myapp.com/callback",
-    cookie_encryption_secret=cookie_encryption_secret,  # openssl rand -base64 32
+    cookie_encryption_secret=os.environ["COOKIE_ENCRYPTION_SECRET"],  # openssl rand -base64 32
 )  # registers /login, /callback, /logout
 
 @app.route("/account")
@@ -174,13 +177,18 @@ def account():
 
 ```python
 # FastAPI -- protect routes with Depends(), FastAPI's idiomatic mechanism
+import os
 from fastapi import Depends, FastAPI
 from scalekit.frameworks.fastapi import ScalekitAuth
 
 app = FastAPI()
-auth = ScalekitAuth(env_url=env_url, client_id=client_id, client_secret=client_secret,
-                     redirect_uri="https://myapp.com/callback",
-                     cookie_encryption_secret=cookie_encryption_secret)
+auth = ScalekitAuth(
+    env_url=os.environ["SCALEKIT_ENV_URL"],
+    client_id=os.environ["SCALEKIT_CLIENT_ID"],
+    client_secret=os.environ["SCALEKIT_CLIENT_SECRET"],
+    redirect_uri="https://myapp.com/callback",
+    cookie_encryption_secret=os.environ["COOKIE_ENCRYPTION_SECRET"],
+)
 auth.install(app)  # registers /login, /callback, /logout
 
 @app.get("/account")
@@ -190,17 +198,21 @@ async def account(user: dict = Depends(auth.requires_auth)):
 
 ```python
 # Django -- settings.py
+import os
+
 MIDDLEWARE = [..., "scalekit.frameworks.django.ScalekitAuthMiddleware"]
-SCALEKIT_ENV_URL = env_url
-SCALEKIT_CLIENT_ID = client_id
-SCALEKIT_CLIENT_SECRET = client_secret
+SCALEKIT_ENV_URL = os.environ["SCALEKIT_ENV_URL"]
+SCALEKIT_CLIENT_ID = os.environ["SCALEKIT_CLIENT_ID"]
+SCALEKIT_CLIENT_SECRET = os.environ["SCALEKIT_CLIENT_SECRET"]
 SCALEKIT_REDIRECT_URI = "https://myapp.com/callback"
-SCALEKIT_COOKIE_ENCRYPTION_SECRET = cookie_encryption_secret
+SCALEKIT_COOKIE_ENCRYPTION_SECRET = os.environ["COOKIE_ENCRYPTION_SECRET"]
 
 # urls.py
+from django.urls import include, path
 urlpatterns = [path("", include("scalekit.frameworks.django")), ...]  # /login, /callback, /logout
 
 # views.py
+from django.http import JsonResponse
 from scalekit.frameworks.django import login_required
 
 @login_required

--- a/README.md
+++ b/README.md
@@ -138,9 +138,72 @@ Explore fully functional sample applications built with popular Python framework
 |-----------|------------|-------------|
 | **FastAPI** | [scalekit-fastapi-example](https://github.com/scalekit-developers/scalekit-fastapi-example) | Modern async Python API framework |
 
-### Encrypted-session middleware examples (in this repo)
+### Full Stack Auth — encrypted-session middleware for Flask, FastAPI, and Django
 
-`scalekit-sdk-python` ships optional Flask, FastAPI, and Django extras (`pip install scalekit-sdk-python[flask|fastapi|django]`) that handle encrypted session cookies, transparent token refresh, and secure login/callback/logout routes for you — see [`examples/flask`](./examples/flask), [`examples/fastapi`](./examples/fastapi), and [`examples/django`](./examples/django) for minimal, runnable versions of the middleware itself. For complete production-oriented sample apps, see the framework repos above.
+The example above is for **Modular SSO**: Scalekit brokers the OAuth exchange with your customer's own IdP via a `connection_id`, and your app owns its own session however it likes.
+
+If instead Scalekit hosts your login UI and you want it to also manage the session lifecycle for you (**Full Stack Auth**), `scalekit-sdk-python` ships optional Flask, FastAPI, and Django extras that handle the encrypted session cookie, transparent token refresh, CSRF-safe login/callback, and full logout for you — no hand-rolled cookies, no manual refresh timing.
+
+```bash
+pip install scalekit-sdk-python[flask]    # or [fastapi], or [django]
+```
+
+```python
+# Flask
+from flask import Flask
+from scalekit.frameworks.flask import ScalekitAuth
+
+app = Flask(__name__)
+auth = ScalekitAuth(
+    app,
+    env_url=env_url, client_id=client_id, client_secret=client_secret,
+    redirect_uri="https://myapp.com/callback",
+    cookie_encryption_secret=cookie_encryption_secret,  # openssl rand -base64 32
+)  # registers /login, /callback, /logout
+
+@app.route("/account")
+@auth.requires_auth
+def account():
+    return {"email": auth.current_user["email"]}
+```
+
+```python
+# FastAPI -- protect routes with Depends(), FastAPI's idiomatic mechanism
+from fastapi import Depends, FastAPI
+from scalekit.frameworks.fastapi import ScalekitAuth
+
+app = FastAPI()
+auth = ScalekitAuth(env_url=env_url, client_id=client_id, client_secret=client_secret,
+                     redirect_uri="https://myapp.com/callback",
+                     cookie_encryption_secret=cookie_encryption_secret)
+auth.install(app)  # registers /login, /callback, /logout
+
+@app.get("/account")
+async def account(user: dict = Depends(auth.requires_auth)):
+    return {"email": user["email"]}
+```
+
+```python
+# Django -- settings.py
+MIDDLEWARE = [..., "scalekit.frameworks.django.ScalekitAuthMiddleware"]
+SCALEKIT_ENV_URL = env_url
+SCALEKIT_CLIENT_ID = client_id
+SCALEKIT_CLIENT_SECRET = client_secret
+SCALEKIT_REDIRECT_URI = "https://myapp.com/callback"
+SCALEKIT_COOKIE_ENCRYPTION_SECRET = cookie_encryption_secret
+
+# urls.py
+urlpatterns = [path("", include("scalekit.frameworks.django")), ...]  # /login, /callback, /logout
+
+# views.py
+from scalekit.frameworks.django import login_required
+
+@login_required
+def account(request):
+    return JsonResponse(request.scalekit_user)
+```
+
+See [`examples/flask`](./examples/flask), [`examples/fastapi`](./examples/fastapi), and [`examples/django`](./examples/django) for complete, runnable versions. For a fuller production-oriented sample app, see the framework repos above.
 
 ## 🔗 Helpful Links
 

--- a/README.md
+++ b/README.md
@@ -149,9 +149,7 @@ Register these under **Dashboard → Authentication → Redirects** before testi
 - **Post Logout Redirect URI** — where users land after full logout. A relative path gets auto-absolutized against the request host, but the resulting absolute URL must still be registered.
 - **Initiate Login URL** — your `/login` path. Scalekit redirects here (not `/callback`) for a bookmarked login page, an IdP portal tile, or an invite/magic link — the login view already handles this correctly, including the `idp_initiated_login` case, with no extra code required.
 
-```bash
-pip install scalekit-sdk-python[flask]    # or [fastapi], or [django]
-```
+pip install "scalekit-sdk-python[flask]"  # or "scalekit-sdk-python[fastapi]" or "scalekit-sdk-python[django]"
 
 ```python
 # Flask

--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Explore fully functional sample applications built with popular Python framework
 |-----------|------------|-------------|
 | **FastAPI** | [scalekit-fastapi-example](https://github.com/scalekit-developers/scalekit-fastapi-example) | Modern async Python API framework |
 
+### Encrypted-session middleware examples (in this repo)
+
+`scalekit-sdk-python` ships optional Flask, FastAPI, and Django extras (`pip install scalekit-sdk-python[flask|fastapi|django]`) that handle encrypted session cookies, transparent token refresh, and secure login/callback/logout routes for you — see [`examples/flask`](./examples/flask), [`examples/fastapi`](./examples/fastapi), and [`examples/django`](./examples/django) for minimal, runnable versions of the middleware itself. For complete production-oriented sample apps, see the framework repos above.
+
 ## 🔗 Helpful Links
 
 ### 📖 Quickstart Guides

--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ The example above is for **Modular SSO**: Scalekit brokers the OAuth exchange wi
 
 If instead Scalekit hosts your login UI and you want it to also manage the session lifecycle for you (**Full Stack Auth**), `scalekit-sdk-python` ships optional Flask, FastAPI, and Django extras that handle the encrypted session cookie, transparent token refresh, CSRF-safe login/callback, and full logout for you — no hand-rolled cookies, no manual refresh timing.
 
+Register these under **Dashboard → Authentication → Redirects** before testing:
+- **Redirect URI** — your `redirect_uri` (the `/callback` path). Scalekit rejects the exchange if this doesn't match exactly.
+- **Post Logout Redirect URI** — where users land after full logout. A relative path gets auto-absolutized against the request host, but the resulting absolute URL must still be registered.
+- **Initiate Login URL** — your `/login` path. Scalekit redirects here (not `/callback`) for a bookmarked login page, an IdP portal tile, or an invite/magic link — the login view already handles this correctly, including the `idp_initiated_login` case, with no extra code required.
+
 ```bash
 pip install scalekit-sdk-python[flask]    # or [fastapi], or [django]
 ```

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+db.sqlite3

--- a/examples/django/.env.example
+++ b/examples/django/.env.example
@@ -2,4 +2,7 @@ SCALEKIT_ENVIRONMENT_URL=https://your-env.scalekit.cloud
 SCALEKIT_CLIENT_ID=skc_xxx
 SCALEKIT_CLIENT_SECRET=your_client_secret
 REDIRECT_URI=http://localhost:5001/callback
-COOKIE_ENCRYPTION_SECRET=generate_with_openssl_rand_base64_32
+# Generate with: openssl rand -base64 32 -- left blank on purpose so an
+# unmodified copy of this file fails fast instead of silently sharing a
+# known, public encryption key with every other unmodified copy.
+COOKIE_ENCRYPTION_SECRET=

--- a/examples/django/.env.example
+++ b/examples/django/.env.example
@@ -1,0 +1,5 @@
+SCALEKIT_ENVIRONMENT_URL=https://your-env.scalekit.cloud
+SCALEKIT_CLIENT_ID=skc_xxx
+SCALEKIT_CLIENT_SECRET=your_client_secret
+REDIRECT_URI=http://localhost:5001/callback
+COOKIE_ENCRYPTION_SECRET=generate_with_openssl_rand_base64_32

--- a/examples/django/README.md
+++ b/examples/django/README.md
@@ -14,7 +14,7 @@ pip install -r requirements.txt
 python manage.py runserver 5001
 ```
 
-Register `http://localhost:5001/callback` as an allowed redirect URI (and `http://localhost:5001/` as an allowed post-logout redirect URI) in your Scalekit dashboard.
+Register these in your Scalekit dashboard: `http://localhost:5001/callback` as an allowed redirect URI, `http://localhost:5001/` as an allowed post-logout redirect URI, and `http://localhost:5001/login` as the Initiate Login URL.
 
 ## What this demonstrates
 

--- a/examples/django/README.md
+++ b/examples/django/README.md
@@ -27,7 +27,7 @@ Register these in your Scalekit dashboard: `http://localhost:5001/callback` as a
 ## In a real app
 
 ```bash
-pip install scalekit-sdk-python[django]
+pip install 'scalekit-sdk-python[django]'
 ```
 
 For a complete, production-oriented sample app (not just this minimal middleware demo), see [`scalekit-django-auth-example`](https://github.com/scalekit-inc/scalekit-django-auth-example).

--- a/examples/django/README.md
+++ b/examples/django/README.md
@@ -1,0 +1,33 @@
+# Django example
+
+Minimal Django project using `scalekit.frameworks.django`'s encrypted-session middleware: login, callback, protected route, full logout — with transparent token refresh handled for you.
+
+## Setup
+
+```bash
+cp .env.example .env
+# fill in SCALEKIT_ENVIRONMENT_URL, SCALEKIT_CLIENT_ID, SCALEKIT_CLIENT_SECRET
+# generate a cookie secret: openssl rand -base64 32
+pip install -r requirements.txt
+# during development against this checkout instead of PyPI:
+#   pip install -e "../..[django]"
+python manage.py runserver 5001
+```
+
+Register `http://localhost:5001/callback` as an allowed redirect URI (and `http://localhost:5001/` as an allowed post-logout redirect URI) in your Scalekit dashboard.
+
+## What this demonstrates
+
+- Config lives in `settings.py` as `SCALEKIT_*` values (matching Django convention) — no `ScalekitAuth` instance to construct yourself.
+- `ScalekitAuthMiddleware` in `MIDDLEWARE` — populates `request.scalekit_user` (claims from the current **access token**, not id_token) on every request and transparently refreshes an expired-but-refreshable session.
+- `@login_required` (from `scalekit.frameworks.django`, not Django's own) — redirects to the configured login path on no/invalid session as a real 302, never a JSON 401.
+- `path("", include("scalekit.frameworks.django"))` — registers `/login`, `/callback`, `/logout`.
+- Full logout by default (ends the Scalekit-side session too via `id_token_hint`), not just the local cookie.
+
+## In a real app
+
+```bash
+pip install scalekit-sdk-python[django]
+```
+
+For a complete, production-oriented sample app (not just this minimal middleware demo), see [`scalekit-django-auth-example`](https://github.com/scalekit-inc/scalekit-django-auth-example).

--- a/examples/django/demo/settings.py
+++ b/examples/django/demo/settings.py
@@ -1,0 +1,49 @@
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SECRET_KEY = "dev-only-not-for-production"
+DEBUG = True
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+
+INSTALLED_APPS = [
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+]
+
+MIDDLEWARE = [
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "scalekit.frameworks.django.ScalekitAuthMiddleware",
+]
+
+ROOT_URLCONF = "demo.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {"context_processors": []},
+    }
+]
+
+WSGI_APPLICATION = "demo.wsgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+    }
+}
+
+USE_TZ = True
+
+# Scalekit middleware config (SCALEKIT_ prefix, read by scalekit.frameworks.django)
+SCALEKIT_ENV_URL = os.environ["SCALEKIT_ENVIRONMENT_URL"]
+SCALEKIT_CLIENT_ID = os.environ["SCALEKIT_CLIENT_ID"]
+SCALEKIT_CLIENT_SECRET = os.environ["SCALEKIT_CLIENT_SECRET"]
+SCALEKIT_REDIRECT_URI = os.environ["REDIRECT_URI"]
+SCALEKIT_COOKIE_ENCRYPTION_SECRET = os.environ["COOKIE_ENCRYPTION_SECRET"]

--- a/examples/django/demo/urls.py
+++ b/examples/django/demo/urls.py
@@ -1,0 +1,22 @@
+from django.http import HttpResponse, JsonResponse
+from django.urls import include, path
+
+from scalekit.frameworks.django import login_required
+
+
+def home(request):
+    return HttpResponse(
+        '<a href="/login">Login</a> | <a href="/account">Account</a> | <a href="/logout">Logout</a>'
+    )
+
+
+@login_required
+def account(request):
+    return JsonResponse(request.scalekit_user)
+
+
+urlpatterns = [
+    path("", home),
+    path("account", account),
+    path("", include("scalekit.frameworks.django")),
+]

--- a/examples/django/demo/urls.py
+++ b/examples/django/demo/urls.py
@@ -5,9 +5,10 @@ from scalekit.frameworks.django import login_required
 
 
 def home(request):
-    return HttpResponse(
-        '<a href="/login">Login</a> | <a href="/account">Account</a> | <a href="/logout">Logout</a>'
-    )
+    # ScalekitAuthMiddleware already populates this on every request.
+    if request.scalekit_user is not None:
+        return HttpResponse('<a href="/account">Account</a> | <a href="/logout">Logout</a>')
+    return HttpResponse('<a href="/login">Login</a>')
 
 
 @login_required

--- a/examples/django/demo/wsgi.py
+++ b/examples/django/demo/wsgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "demo.settings")
+
+application = get_wsgi_application()

--- a/examples/django/manage.py
+++ b/examples/django/manage.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "demo.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/examples/django/requirements.txt
+++ b/examples/django/requirements.txt
@@ -1,0 +1,2 @@
+scalekit-sdk-python[django]
+python-dotenv

--- a/examples/fastapi/.env.example
+++ b/examples/fastapi/.env.example
@@ -1,0 +1,6 @@
+SCALEKIT_ENVIRONMENT_URL=https://your-env.scalekit.cloud
+SCALEKIT_CLIENT_ID=skc_xxx
+SCALEKIT_CLIENT_SECRET=your_client_secret
+REDIRECT_URI=http://localhost:5001/callback
+COOKIE_ENCRYPTION_SECRET=generate_with_openssl_rand_base64_32
+PORT=5001

--- a/examples/fastapi/.env.example
+++ b/examples/fastapi/.env.example
@@ -2,5 +2,8 @@ SCALEKIT_ENVIRONMENT_URL=https://your-env.scalekit.cloud
 SCALEKIT_CLIENT_ID=skc_xxx
 SCALEKIT_CLIENT_SECRET=your_client_secret
 REDIRECT_URI=http://localhost:5001/callback
-COOKIE_ENCRYPTION_SECRET=generate_with_openssl_rand_base64_32
+# Generate with: openssl rand -base64 32 -- left blank on purpose so an
+# unmodified copy of this file fails fast instead of silently sharing a
+# known, public encryption key with every other unmodified copy.
+COOKIE_ENCRYPTION_SECRET=
 PORT=5001

--- a/examples/fastapi/README.md
+++ b/examples/fastapi/README.md
@@ -14,7 +14,7 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Register `http://localhost:5001/callback` as an allowed redirect URI (and `http://localhost:5001/` as an allowed post-logout redirect URI) in your Scalekit dashboard.
+Register these in your Scalekit dashboard: `http://localhost:5001/callback` as an allowed redirect URI, `http://localhost:5001/` as an allowed post-logout redirect URI, and `http://localhost:5001/login` as the Initiate Login URL.
 
 ## What this demonstrates
 

--- a/examples/fastapi/README.md
+++ b/examples/fastapi/README.md
@@ -1,0 +1,32 @@
+# FastAPI example
+
+Minimal FastAPI app using `ScalekitAuth` from `scalekit-sdk-python`'s encrypted-session middleware: login, callback, protected route, full logout — with transparent token refresh handled for you.
+
+## Setup
+
+```bash
+cp .env.example .env
+# fill in SCALEKIT_ENVIRONMENT_URL, SCALEKIT_CLIENT_ID, SCALEKIT_CLIENT_SECRET
+# generate a cookie secret: openssl rand -base64 32
+pip install -r requirements.txt
+# during development against this checkout instead of PyPI:
+#   pip install -e "../..[fastapi]"
+python app.py
+```
+
+Register `http://localhost:5001/callback` as an allowed redirect URI (and `http://localhost:5001/` as an allowed post-logout redirect URI) in your Scalekit dashboard.
+
+## What this demonstrates
+
+- `auth.install(app)` — registers `/login`, `/callback`, `/logout` and the redirect exception handler.
+- `Depends(auth.requires_auth)` — FastAPI's idiomatic protection mechanism (not a decorator); redirects to `/login` on no/invalid session as a real 302 (never a JSON 401 from a raised `HTTPException`), transparently refreshes an expired-but-refreshable session.
+- The injected `user` dict is claims from the current **access token** (not id_token), so any custom claims you've configured in the Scalekit dashboard show up here, and stay fresh across refreshes.
+- Full logout by default (ends the Scalekit-side session too via `id_token_hint`), not just the local cookie.
+
+## In a real app
+
+```bash
+pip install scalekit-sdk-python[fastapi]
+```
+
+For a complete, production-oriented sample app (not just this minimal middleware demo), see [`scalekit-fastapi-auth-example`](https://github.com/scalekit-inc/scalekit-fastapi-auth-example).

--- a/examples/fastapi/app.py
+++ b/examples/fastapi/app.py
@@ -1,0 +1,36 @@
+import os
+
+from dotenv import load_dotenv
+from fastapi import Depends, FastAPI
+from fastapi.responses import HTMLResponse
+
+from scalekit.frameworks.fastapi import ScalekitAuth
+
+load_dotenv()
+
+app = FastAPI()
+
+auth = ScalekitAuth(
+    env_url=os.environ["SCALEKIT_ENVIRONMENT_URL"],
+    client_id=os.environ["SCALEKIT_CLIENT_ID"],
+    client_secret=os.environ["SCALEKIT_CLIENT_SECRET"],
+    redirect_uri=os.environ["REDIRECT_URI"],
+    cookie_encryption_secret=os.environ["COOKIE_ENCRYPTION_SECRET"],
+)
+auth.install(app)
+
+
+@app.get("/", response_class=HTMLResponse)
+async def home():
+    return '<a href="/login">Login</a> | <a href="/account">Account</a> | <a href="/logout">Logout</a>'
+
+
+@app.get("/account")
+async def account(user: dict = Depends(auth.requires_auth)):
+    return user
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, port=int(os.environ.get("PORT", 5001)))

--- a/examples/fastapi/app.py
+++ b/examples/fastapi/app.py
@@ -1,7 +1,7 @@
 import os
 
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import HTMLResponse
 
 from scalekit.frameworks.fastapi import ScalekitAuth
@@ -21,8 +21,10 @@ auth.install(app)
 
 
 @app.get("/", response_class=HTMLResponse)
-async def home():
-    return '<a href="/login">Login</a> | <a href="/account">Account</a> | <a href="/logout">Logout</a>'
+async def home(request: Request):
+    if auth.manager.cookie_name in request.cookies:
+        return '<a href="/account">Account</a> | <a href="/logout">Logout</a>'
+    return '<a href="/login">Login</a>'
 
 
 @app.get("/account")

--- a/examples/fastapi/requirements.txt
+++ b/examples/fastapi/requirements.txt
@@ -1,0 +1,3 @@
+scalekit-sdk-python[fastapi]
+python-dotenv
+uvicorn

--- a/examples/flask/.env.example
+++ b/examples/flask/.env.example
@@ -1,0 +1,6 @@
+SCALEKIT_ENVIRONMENT_URL=https://your-env.scalekit.cloud
+SCALEKIT_CLIENT_ID=skc_xxx
+SCALEKIT_CLIENT_SECRET=your_client_secret
+REDIRECT_URI=http://localhost:5001/callback
+COOKIE_ENCRYPTION_SECRET=generate_with_openssl_rand_base64_32
+PORT=5001

--- a/examples/flask/.env.example
+++ b/examples/flask/.env.example
@@ -2,5 +2,8 @@ SCALEKIT_ENVIRONMENT_URL=https://your-env.scalekit.cloud
 SCALEKIT_CLIENT_ID=skc_xxx
 SCALEKIT_CLIENT_SECRET=your_client_secret
 REDIRECT_URI=http://localhost:5001/callback
-COOKIE_ENCRYPTION_SECRET=generate_with_openssl_rand_base64_32
+# Generate with: openssl rand -base64 32 -- left blank on purpose so an
+# unmodified copy of this file fails fast instead of silently sharing a
+# known, public encryption key with every other unmodified copy.
+COOKIE_ENCRYPTION_SECRET=
 PORT=5001

--- a/examples/flask/README.md
+++ b/examples/flask/README.md
@@ -14,7 +14,7 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Register `http://localhost:5001/callback` as an allowed redirect URI (and `http://localhost:5001/` as an allowed post-logout redirect URI) in your Scalekit dashboard.
+Register these in your Scalekit dashboard: `http://localhost:5001/callback` as an allowed redirect URI, `http://localhost:5001/` as an allowed post-logout redirect URI, and `http://localhost:5001/login` as the Initiate Login URL.
 
 ## What this demonstrates
 

--- a/examples/flask/README.md
+++ b/examples/flask/README.md
@@ -1,0 +1,32 @@
+# Flask example
+
+Minimal Flask app using `ScalekitAuth` from `scalekit-sdk-python`'s encrypted-session middleware: login, callback, protected route, full logout — with transparent token refresh handled for you.
+
+## Setup
+
+```bash
+cp .env.example .env
+# fill in SCALEKIT_ENVIRONMENT_URL, SCALEKIT_CLIENT_ID, SCALEKIT_CLIENT_SECRET
+# generate a cookie secret: openssl rand -base64 32
+pip install -r requirements.txt
+# during development against this checkout instead of PyPI:
+#   pip install -e "../..[flask]"
+python app.py
+```
+
+Register `http://localhost:5001/callback` as an allowed redirect URI (and `http://localhost:5001/` as an allowed post-logout redirect URI) in your Scalekit dashboard.
+
+## What this demonstrates
+
+- `ScalekitAuth(app, ...)` — registers `/login`, `/callback`, `/logout` for you.
+- `@auth.requires_auth` — protects a view; redirects to `/login` on no/invalid session (never a JSON 401), transparently refreshes an expired-but-refreshable session.
+- `auth.current_user` — claims from the current **access token** (not id_token), so any custom claims you've configured in the Scalekit dashboard show up here, and stay fresh across refreshes.
+- Full logout by default (ends the Scalekit-side session too via `id_token_hint`), not just the local cookie.
+
+## In a real app
+
+```bash
+pip install scalekit-sdk-python[flask]
+```
+
+For a complete, production-oriented sample app (not just this minimal middleware demo), see [`scalekit-flask-auth-example`](https://github.com/scalekit-inc/scalekit-flask-auth-example).

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -34,4 +34,4 @@ def account():
 
 
 if __name__ == "__main__":
-    app.run(port=int(os.environ.get("PORT", 5001)), debug=True)
+    app.run(port=int(os.environ.get("PORT", 5001)))

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -2,6 +2,7 @@ import os
 
 from dotenv import load_dotenv
 from flask import Flask
+from flask import request as flask_request
 
 from scalekit.frameworks.flask import ScalekitAuth
 
@@ -21,7 +22,9 @@ auth = ScalekitAuth(
 
 @app.route("/")
 def home():
-    return '<a href="/login">Login</a> | <a href="/account">Account</a> | <a href="/logout">Logout</a>'
+    if auth.manager.cookie_name in flask_request.cookies:
+        return '<a href="/account">Account</a> | <a href="/logout">Logout</a>'
+    return '<a href="/login">Login</a>'
 
 
 @app.route("/account")

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -1,0 +1,34 @@
+import os
+
+from dotenv import load_dotenv
+from flask import Flask
+
+from scalekit.frameworks.flask import ScalekitAuth
+
+load_dotenv()
+
+app = Flask(__name__)
+
+auth = ScalekitAuth(
+    app,
+    env_url=os.environ["SCALEKIT_ENVIRONMENT_URL"],
+    client_id=os.environ["SCALEKIT_CLIENT_ID"],
+    client_secret=os.environ["SCALEKIT_CLIENT_SECRET"],
+    redirect_uri=os.environ["REDIRECT_URI"],
+    cookie_encryption_secret=os.environ["COOKIE_ENCRYPTION_SECRET"],
+)
+
+
+@app.route("/")
+def home():
+    return '<a href="/login">Login</a> | <a href="/account">Account</a> | <a href="/logout">Logout</a>'
+
+
+@app.route("/account")
+@auth.requires_auth
+def account():
+    return auth.current_user
+
+
+if __name__ == "__main__":
+    app.run(port=int(os.environ.get("PORT", 5001)), debug=True)

--- a/examples/flask/requirements.txt
+++ b/examples/flask/requirements.txt
@@ -1,0 +1,2 @@
+scalekit-sdk-python[flask]
+python-dotenv

--- a/scalekit/_version.py
+++ b/scalekit/_version.py
@@ -1,3 +1,3 @@
 # Single source of truth for the SDK version.
 # Import this in setup.py and scalekit/core.py — never hardcode the version elsewhere.
-__version__ = "2.16.0"
+__version__ = "2.17.0"

--- a/scalekit/frameworks/django.py
+++ b/scalekit/frameworks/django.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import time
+from functools import lru_cache, wraps
+from typing import Any, Callable, Optional
+
+try:
+    from django.conf import settings as django_settings
+    from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+    from django.urls import path
+except ImportError as exc:  # pragma: no cover -- exercised only without the extra installed
+    raise ImportError(
+        "Django integration requires the 'django' extra: "
+        "pip install scalekit-sdk-python[django]"
+    ) from exc
+
+from scalekit.client import ScalekitClient
+from scalekit.common.scalekit import (
+    AuthorizationUrlOptions,
+    CodeAuthenticationOptions,
+    LogoutUrlOptions,
+)
+from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
+from scalekit.middleware.session_crypto import InvalidSessionError, decrypt_session
+from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
+
+
+class _DjangoRequestAdapter:
+    """RequestAdapter implementation backed by a Django HttpRequest."""
+
+    def __init__(self, request: HttpRequest):
+        self._request = request
+
+    def get_cookie(self, name: str) -> Optional[str]:
+        return self._request.COOKIES.get(name)
+
+    def get_request_url(self) -> str:
+        return self._request.build_absolute_uri()
+
+
+class _DjangoResponseAdapter:
+    """ResponseAdapter implementation that mutates a Django HttpResponse in place."""
+
+    def __init__(self, response: HttpResponse):
+        self.response = response
+
+    def set_cookie(
+        self,
+        name: str,
+        value: str,
+        *,
+        max_age: Optional[int] = None,
+        secure: bool = True,
+        http_only: bool = True,
+        same_site: str = "Lax",
+        domain: Optional[str] = None,
+        path: str = "/",
+    ) -> None:
+        self.response.set_cookie(
+            name,
+            value,
+            max_age=max_age,
+            secure=secure,
+            httponly=http_only,
+            samesite=same_site,
+            domain=domain,
+            path=path,
+        )
+
+    def delete_cookie(
+        self, name: str, *, path: str = "/", domain: Optional[str] = None
+    ) -> None:
+        self.response.delete_cookie(name, path=path, domain=domain)
+
+
+def _setting(name: str, default: Any = None, required: bool = False) -> Any:
+    value = getattr(django_settings, name, default)
+    if required and not value:
+        raise ValueError(
+            f"Django setting {name} is required to use scalekit.frameworks.django"
+        )
+    return value
+
+
+class ScalekitAuthConfig:
+    """
+    Holds the shared ScalekitClient + SessionRefreshManager, built once from
+    Django settings (all read with an SCALEKIT_ prefix, matching Django
+    convention for third-party app config):
+
+        SCALEKIT_CLIENT_ID, SCALEKIT_CLIENT_SECRET, SCALEKIT_ENV_URL,
+        SCALEKIT_REDIRECT_URI, SCALEKIT_COOKIE_ENCRYPTION_SECRET (required --
+        see scalekit.middleware.session_crypto for why there is intentionally
+        no default), SCALEKIT_COOKIE_NAME (optional), SCALEKIT_LOGIN_PATH
+        (optional, default "/login"), SCALEKIT_POST_LOGIN_REDIRECT (optional,
+        default "/"), SCALEKIT_POST_LOGOUT_REDIRECT_URI (optional, falls back
+        to SCALEKIT_POST_LOGIN_REDIRECT), SCALEKIT_FULL_LOGOUT (optional
+        bool, default True).
+
+    SCALEKIT_CLIENT (an already-constructed ScalekitClient) can be set
+    directly, primarily for tests -- normal usage constructs one from the
+    ID/secret/env_url settings above.
+    """
+
+    def __init__(self):
+        client = _setting("SCALEKIT_CLIENT", None)
+        if client is None:
+            client = ScalekitClient(
+                env_url=_setting("SCALEKIT_ENV_URL", required=True),
+                client_id=_setting("SCALEKIT_CLIENT_ID", required=True),
+                client_secret=_setting("SCALEKIT_CLIENT_SECRET", required=True),
+            )
+        self.client = client
+        self.redirect_uri = _setting("SCALEKIT_REDIRECT_URI", required=True)
+        self.login_path = _setting("SCALEKIT_LOGIN_PATH", "/login")
+        self.post_login_redirect = _setting("SCALEKIT_POST_LOGIN_REDIRECT", "/")
+        self.post_logout_redirect_uri = (
+            _setting("SCALEKIT_POST_LOGOUT_REDIRECT_URI") or self.post_login_redirect
+        )
+        self.full_logout = _setting("SCALEKIT_FULL_LOGOUT", True)
+
+        # Raises immediately if the secret is missing.
+        self.manager = SessionRefreshManager(
+            self.client,
+            _setting("SCALEKIT_COOKIE_ENCRYPTION_SECRET", required=True),
+            cookie_name=_setting("SCALEKIT_COOKIE_NAME", DEFAULT_COOKIE_NAME),
+        )
+
+
+@lru_cache(maxsize=1)
+def get_config() -> ScalekitAuthConfig:
+    return ScalekitAuthConfig()
+
+
+class ScalekitAuthMiddleware:
+    """
+    Add to MIDDLEWARE in settings.py. Populates `request.scalekit_user` (None
+    if not authenticated) and transparently refreshes the session cookie on
+    every request. Mirrors Django's own convention (AuthenticationMiddleware
+    populates `request.user`, `login_required` enforces it) -- this
+    middleware does NOT itself enforce authentication; use `login_required`
+    on individual views for that.
+    """
+
+    def __init__(self, get_response: Callable):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest):
+        config = get_config()
+        result = config.manager.check(_DjangoRequestAdapter(request))
+        request.scalekit_user = result.user if result.authenticated else None
+        request.scalekit_session_result = result
+
+        response = self.get_response(request)
+
+        if result.new_cookie_value:
+            _DjangoResponseAdapter(response).set_cookie(
+                config.manager.cookie_name, result.new_cookie_value
+            )
+        elif result.should_clear_cookie:
+            _DjangoResponseAdapter(response).delete_cookie(config.manager.cookie_name)
+
+        return response
+
+
+def login_required(view_func: Callable) -> Callable:
+    """
+    View decorator: redirects to SCALEKIT_LOGIN_PATH with a real 302 if
+    `request.scalekit_user` isn't set. Requires ScalekitAuthMiddleware to be
+    installed. Same "real redirect, never a JSON 401" guarantee as the
+    Flask/FastAPI integrations -- a JSON 401 is exactly what a background
+    fetch/XHR would silently swallow, which is the failure mode this whole
+    design exists to avoid.
+    """
+
+    @wraps(view_func)
+    def wrapped(request: HttpRequest, *args, **kwargs):
+        if getattr(request, "scalekit_user", None) is None:
+            return HttpResponseRedirect(get_config().login_path)
+        return view_func(request, *args, **kwargs)
+
+    return wrapped
+
+
+def login_view(request: HttpRequest) -> HttpResponse:
+    config = get_config()
+    options = AuthorizationUrlOptions()
+    # offline_access is required to get a refresh_token back at all -- see
+    # scalekit.frameworks.flask for the full explanation.
+    options.scopes = ["openid", "profile", "email", "offline_access"]
+    url = config.client.get_authorization_url(config.redirect_uri, options)
+    return HttpResponseRedirect(url)
+
+
+def callback_view(request: HttpRequest) -> HttpResponse:
+    config = get_config()
+    code = request.GET.get("code")
+    result = config.client.authenticate_with_code(
+        code, config.redirect_uri, CodeAuthenticationOptions()
+    )
+    # Access-token claims (not id_token claims) are the source of truth for
+    # `user` -- see scalekit.frameworks.flask for the full reasoning.
+    claims = config.client.validate_access_token_and_get_claims(result["access_token"])
+    payload = {
+        "user": claims,
+        "access_token": result["access_token"],
+        "refresh_token": result.get("refresh_token"),
+        "id_token": result.get("id_token"),
+        "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
+    }
+    cookie_value = config.manager.create_session_cookie(payload)
+    response = HttpResponseRedirect(config.post_login_redirect)
+    _DjangoResponseAdapter(response).set_cookie(config.manager.cookie_name, cookie_value)
+    return response
+
+
+def logout_view(request: HttpRequest) -> HttpResponse:
+    config = get_config()
+    cookie_value = request.COOKIES.get(config.manager.cookie_name)
+    id_token = None
+    if cookie_value:
+        try:
+            payload = decrypt_session(cookie_value, config.manager._secret)
+            id_token = payload.get("id_token")
+        except InvalidSessionError:
+            pass  # nothing usable to hint with -- fall through to local-only redirect
+
+    redirect_url = config.post_logout_redirect_uri
+    if config.full_logout and id_token:
+        # Scalekit requires an absolute, dashboard-registered post-logout
+        # redirect URI -- absolutize a relative default against the current
+        # request, same as the Flask/FastAPI adapters.
+        absolute_redirect_uri = config.post_logout_redirect_uri
+        if not absolute_redirect_uri.startswith(("http://", "https://")):
+            absolute_redirect_uri = request.build_absolute_uri(absolute_redirect_uri)
+        options = LogoutUrlOptions()
+        options.id_token_hint = id_token
+        options.post_logout_redirect_uri = absolute_redirect_uri
+        redirect_url = config.client.get_logout_url(options)
+
+    response = HttpResponseRedirect(redirect_url)
+    _DjangoResponseAdapter(response).delete_cookie(config.manager.cookie_name)
+    return response
+
+
+# Include via: path("auth/", include("scalekit.frameworks.django"))
+urlpatterns = [
+    path("login/", login_view, name="scalekit_login"),
+    path("callback/", callback_view, name="scalekit_callback"),
+    path("logout/", logout_view, name="scalekit_logout"),
+]

--- a/scalekit/frameworks/django.py
+++ b/scalekit/frameworks/django.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import secrets
+import logging
 import time
 from functools import lru_cache, wraps
 from typing import Any, Callable, Optional
@@ -21,14 +21,16 @@ from scalekit.common.scalekit import (
     CodeAuthenticationOptions,
     LogoutUrlOptions,
 )
+from scalekit.middleware.csrf_state import (
+    STATE_COOKIE_MAX_AGE,
+    STATE_COOKIE_NAME,
+    generate_state,
+    verify_state,
+)
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
 from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
 
-# Short-lived cookie carrying the OAuth `state` value between /login and
-# /callback -- see scalekit.frameworks.flask for the full CSRF reasoning
-# (identical here, not framework-specific).
-_STATE_COOKIE_NAME = "sk_oauth_state"
-_STATE_COOKIE_MAX_AGE = 600  # 10 minutes
+logger = logging.getLogger("scalekit.frameworks.django")
 
 
 class _DjangoRequestAdapter:
@@ -197,12 +199,12 @@ def login_view(request: HttpRequest) -> HttpResponse:
     # Bind this authorization request to the browser that started it, so
     # callback_view can reject a forged callback carrying an attacker's own
     # authorization code (CSRF) -- see scalekit.frameworks.flask.
-    state = secrets.token_urlsafe(32)
+    state = generate_state()
     options.state = state
     url = config.client.get_authorization_url(config.redirect_uri, options)
     response = HttpResponseRedirect(url)
     _DjangoResponseAdapter(response).set_cookie(
-        _STATE_COOKIE_NAME, state, max_age=_STATE_COOKIE_MAX_AGE
+        STATE_COOKIE_NAME, state, max_age=STATE_COOKIE_MAX_AGE
     )
     return response
 
@@ -212,7 +214,7 @@ def callback_view(request: HttpRequest) -> HttpResponse:
 
     def _redirect_to_login():
         resp = HttpResponseRedirect(config.login_path)
-        _DjangoResponseAdapter(resp).delete_cookie(_STATE_COOKIE_NAME)
+        _DjangoResponseAdapter(resp).delete_cookie(STATE_COOKIE_NAME)
         return resp
 
     # The provider redirects here with `error` (no `code`) if the user
@@ -223,13 +225,9 @@ def callback_view(request: HttpRequest) -> HttpResponse:
     if error or not code:
         return _redirect_to_login()
 
-    stored_state = request.COOKIES.get(_STATE_COOKIE_NAME)
+    stored_state = request.COOKIES.get(STATE_COOKIE_NAME)
     returned_state = request.GET.get("state")
-    if (
-        not stored_state
-        or not returned_state
-        or not secrets.compare_digest(stored_state, returned_state)
-    ):
+    if not verify_state(stored_state, returned_state):
         # Missing or mismatched state -- this callback did not originate
         # from a /login this browser actually made. Refuse the exchange.
         return _redirect_to_login()
@@ -242,21 +240,25 @@ def callback_view(request: HttpRequest) -> HttpResponse:
         # Access-token claims (not id_token claims) are the source of truth for
         # `user` -- see scalekit.frameworks.flask for the full reasoning.
         claims = config.client.validate_access_token_and_get_claims(access_token)
+        payload = {
+            "user": claims,
+            "access_token": access_token,
+            "refresh_token": result.get("refresh_token"),
+            "id_token": result.get("id_token"),
+            "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
+        }
+        # create_session_cookie raises if the encrypted payload exceeds the
+        # browser cookie size limit -- must stay inside this try, not just
+        # the network calls above, or this view raises with no wrapper.
+        cookie_value = config.manager.create_session_cookie(payload)
     except Exception:
+        logger.exception("login callback failed; redirecting to login")
         return _redirect_to_login()
 
-    payload = {
-        "user": claims,
-        "access_token": access_token,
-        "refresh_token": result.get("refresh_token"),
-        "id_token": result.get("id_token"),
-        "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
-    }
-    cookie_value = config.manager.create_session_cookie(payload)
     response = HttpResponseRedirect(config.post_login_redirect)
     adapter = _DjangoResponseAdapter(response)
     adapter.set_cookie(config.manager.cookie_name, cookie_value)
-    adapter.delete_cookie(_STATE_COOKIE_NAME)
+    adapter.delete_cookie(STATE_COOKIE_NAME)
     return response
 
 

--- a/scalekit/frameworks/django.py
+++ b/scalekit/frameworks/django.py
@@ -4,6 +4,7 @@ import logging
 import time
 from functools import lru_cache, wraps
 from typing import Any, Callable, Optional
+from urllib.parse import quote
 
 try:
     from django.conf import settings as django_settings
@@ -22,9 +23,11 @@ from scalekit.common.scalekit import (
     LogoutUrlOptions,
 )
 from scalekit.middleware.csrf_state import (
+    RETURN_TO_COOKIE_NAME,
     STATE_COOKIE_MAX_AGE,
     STATE_COOKIE_NAME,
     generate_state,
+    sanitize_return_to,
     verify_state,
 )
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
@@ -49,8 +52,13 @@ class _DjangoRequestAdapter:
 class _DjangoResponseAdapter:
     """ResponseAdapter implementation that mutates a Django HttpResponse in place."""
 
-    def __init__(self, response: HttpResponse):
+    def __init__(self, response: HttpResponse, *, secure: bool = True):
         self.response = response
+        # Default for callers that don't pass `secure` explicitly (e.g.
+        # SessionRefreshManager.apply()-style callers that only know the
+        # ResponseAdapter interface, not SCALEKIT_COOKIE_SECURE) -- every
+        # call site below now constructs this with secure=config.cookie_secure.
+        self._default_secure = secure
 
     def set_cookie(
         self,
@@ -58,7 +66,7 @@ class _DjangoResponseAdapter:
         value: str,
         *,
         max_age: Optional[int] = None,
-        secure: bool = True,
+        secure: Optional[bool] = None,
         http_only: bool = True,
         same_site: str = "Lax",
         domain: Optional[str] = None,
@@ -68,7 +76,7 @@ class _DjangoResponseAdapter:
             name,
             value,
             max_age=max_age,
-            secure=secure,
+            secure=self._default_secure if secure is None else secure,
             httponly=http_only,
             samesite=same_site,
             domain=domain,
@@ -126,6 +134,11 @@ class ScalekitAuthConfig:
             _setting("SCALEKIT_POST_LOGOUT_REDIRECT_URI") or self.post_login_redirect
         )
         self.full_logout = _setting("SCALEKIT_FULL_LOGOUT", True)
+        # Right default for production. Chrome (and some other browsers) silently
+        # drop a Secure cookie set over plain http://localhost, which looks like a
+        # session that never sticks -- set SCALEKIT_COOKIE_SECURE=False for local
+        # HTTP dev.
+        self.cookie_secure = _setting("SCALEKIT_COOKIE_SECURE", True)
 
         # Raises immediately if the secret is missing.
         self.manager = SessionRefreshManager(
@@ -162,13 +175,39 @@ class ScalekitAuthMiddleware:
         response = self.get_response(request)
 
         if result.new_cookie_value:
-            _DjangoResponseAdapter(response).set_cookie(
+            _DjangoResponseAdapter(response, secure=config.cookie_secure).set_cookie(
                 config.manager.cookie_name, result.new_cookie_value
             )
         elif result.should_clear_cookie:
             _DjangoResponseAdapter(response).delete_cookie(config.manager.cookie_name)
 
         return response
+
+
+def get_session(request: HttpRequest) -> Optional[dict]:
+    """
+    Read-only session lookup -- for use outside a `login_required`-gated view
+    (e.g. a homepage that wants to show a logged-in/logged-out state without
+    gating the whole route). Never refreshes or writes a new cookie.
+
+    Returns `{"user": ..., "expires_at": ...}`, or `None` if there's no valid
+    session. `user` is the access-token claims (not tokens themselves) --
+    this function never returns `access_token`, `refresh_token`, or
+    `id_token`.
+
+    Note: ScalekitAuthMiddleware already sets `request.scalekit_user` on
+    every request (`None` if unauthenticated), so most views can just read
+    that directly. Use `get_session()` instead when you also need
+    `expires_at`.
+    """
+    config = get_config()
+    cookie_value = request.COOKIES.get(config.manager.cookie_name)
+    if not cookie_value:
+        return None
+    payload = config.manager.read_session(cookie_value)
+    if payload is None:
+        return None
+    return {"user": payload.get("user"), "expires_at": payload.get("expires_at")}
 
 
 def login_required(view_func: Callable) -> Callable:
@@ -184,7 +223,11 @@ def login_required(view_func: Callable) -> Callable:
     @wraps(view_func)
     def wrapped(request: HttpRequest, *args, **kwargs):
         if getattr(request, "scalekit_user", None) is None:
-            return HttpResponseRedirect(get_config().login_path)
+            # Preserve the page the caller was trying to reach so callback_view
+            # can send them back there instead of the fixed post_login_redirect.
+            current_path = request.get_full_path()
+            location = f"{get_config().login_path}?returnTo={quote(current_path, safe='')}"
+            return HttpResponseRedirect(location)
         return view_func(request, *args, **kwargs)
 
     return wrapped
@@ -218,9 +261,16 @@ def login_view(request: HttpRequest) -> HttpResponse:
     options.state = state
     url = config.client.get_authorization_url(config.redirect_uri, options)
     response = HttpResponseRedirect(url)
-    _DjangoResponseAdapter(response).set_cookie(
-        STATE_COOKIE_NAME, state, max_age=STATE_COOKIE_MAX_AGE
-    )
+    adapter = _DjangoResponseAdapter(response, secure=config.cookie_secure)
+    adapter.set_cookie(STATE_COOKIE_NAME, state, max_age=STATE_COOKIE_MAX_AGE)
+
+    # Preserve the page the caller was trying to reach (set by
+    # login_required's redirect) so callback_view can send them back there
+    # instead of the fixed post_login_redirect -- re-validated here since
+    # query strings are always attacker-influenceable.
+    return_to = sanitize_return_to(request.GET.get("returnTo"))
+    if return_to:
+        adapter.set_cookie(RETURN_TO_COOKIE_NAME, return_to, max_age=STATE_COOKIE_MAX_AGE)
     return response
 
 
@@ -229,7 +279,9 @@ def callback_view(request: HttpRequest) -> HttpResponse:
 
     def _redirect_to_login():
         resp = HttpResponseRedirect(config.login_path)
-        _DjangoResponseAdapter(resp).delete_cookie(STATE_COOKIE_NAME)
+        adapter = _DjangoResponseAdapter(resp, secure=config.cookie_secure)
+        adapter.delete_cookie(STATE_COOKIE_NAME)
+        adapter.delete_cookie(RETURN_TO_COOKIE_NAME)
         return resp
 
     # The provider redirects here with `error` (no `code`) if the user
@@ -270,10 +322,12 @@ def callback_view(request: HttpRequest) -> HttpResponse:
         logger.exception("login callback failed; redirecting to login")
         return _redirect_to_login()
 
-    response = HttpResponseRedirect(config.post_login_redirect)
-    adapter = _DjangoResponseAdapter(response)
+    return_to = sanitize_return_to(request.COOKIES.get(RETURN_TO_COOKIE_NAME))
+    response = HttpResponseRedirect(return_to or config.post_login_redirect)
+    adapter = _DjangoResponseAdapter(response, secure=config.cookie_secure)
     adapter.set_cookie(config.manager.cookie_name, cookie_value)
     adapter.delete_cookie(STATE_COOKIE_NAME)
+    adapter.delete_cookie(RETURN_TO_COOKIE_NAME)
     return response
 
 

--- a/scalekit/frameworks/django.py
+++ b/scalekit/frameworks/django.py
@@ -243,9 +243,12 @@ def logout_view(request: HttpRequest) -> HttpResponse:
     return response
 
 
-# Include via: path("auth/", include("scalekit.frameworks.django"))
+# No trailing slashes -- matches the Flask/FastAPI adapters' paths
+# ("/login", "/callback", "/logout") so a redirect_uri registered in the
+# Scalekit dashboard for one framework works unchanged for the others.
+# Include via: path("", include("scalekit.frameworks.django"))
 urlpatterns = [
-    path("login/", login_view, name="scalekit_login"),
-    path("callback/", callback_view, name="scalekit_callback"),
-    path("logout/", logout_view, name="scalekit_logout"),
+    path("login", login_view, name="scalekit_login"),
+    path("callback", callback_view, name="scalekit_callback"),
+    path("logout", logout_view, name="scalekit_logout"),
 ]

--- a/scalekit/frameworks/django.py
+++ b/scalekit/frameworks/django.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 import time
 from functools import lru_cache, wraps
 from typing import Any, Callable, Optional
@@ -21,8 +22,13 @@ from scalekit.common.scalekit import (
     LogoutUrlOptions,
 )
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
-from scalekit.middleware.session_crypto import InvalidSessionError, decrypt_session
 from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
+
+# Short-lived cookie carrying the OAuth `state` value between /login and
+# /callback -- see scalekit.frameworks.flask for the full CSRF reasoning
+# (identical here, not framework-specific).
+_STATE_COOKIE_NAME = "sk_oauth_state"
+_STATE_COOKIE_MAX_AGE = 600  # 10 minutes
 
 
 class _DjangoRequestAdapter:
@@ -188,29 +194,69 @@ def login_view(request: HttpRequest) -> HttpResponse:
     # offline_access is required to get a refresh_token back at all -- see
     # scalekit.frameworks.flask for the full explanation.
     options.scopes = ["openid", "profile", "email", "offline_access"]
+    # Bind this authorization request to the browser that started it, so
+    # callback_view can reject a forged callback carrying an attacker's own
+    # authorization code (CSRF) -- see scalekit.frameworks.flask.
+    state = secrets.token_urlsafe(32)
+    options.state = state
     url = config.client.get_authorization_url(config.redirect_uri, options)
-    return HttpResponseRedirect(url)
+    response = HttpResponseRedirect(url)
+    _DjangoResponseAdapter(response).set_cookie(
+        _STATE_COOKIE_NAME, state, max_age=_STATE_COOKIE_MAX_AGE
+    )
+    return response
 
 
 def callback_view(request: HttpRequest) -> HttpResponse:
     config = get_config()
+
+    def _redirect_to_login():
+        resp = HttpResponseRedirect(config.login_path)
+        _DjangoResponseAdapter(resp).delete_cookie(_STATE_COOKIE_NAME)
+        return resp
+
+    # The provider redirects here with `error` (no `code`) if the user
+    # cancels consent or the request is otherwise rejected -- never reflect
+    # error/error_description into the response, it's attacker-influenced.
+    error = request.GET.get("error")
     code = request.GET.get("code")
-    result = config.client.authenticate_with_code(
-        code, config.redirect_uri, CodeAuthenticationOptions()
-    )
-    # Access-token claims (not id_token claims) are the source of truth for
-    # `user` -- see scalekit.frameworks.flask for the full reasoning.
-    claims = config.client.validate_access_token_and_get_claims(result["access_token"])
+    if error or not code:
+        return _redirect_to_login()
+
+    stored_state = request.COOKIES.get(_STATE_COOKIE_NAME)
+    returned_state = request.GET.get("state")
+    if (
+        not stored_state
+        or not returned_state
+        or not secrets.compare_digest(stored_state, returned_state)
+    ):
+        # Missing or mismatched state -- this callback did not originate
+        # from a /login this browser actually made. Refuse the exchange.
+        return _redirect_to_login()
+
+    try:
+        result = config.client.authenticate_with_code(
+            code, config.redirect_uri, CodeAuthenticationOptions()
+        )
+        access_token = result["access_token"]
+        # Access-token claims (not id_token claims) are the source of truth for
+        # `user` -- see scalekit.frameworks.flask for the full reasoning.
+        claims = config.client.validate_access_token_and_get_claims(access_token)
+    except Exception:
+        return _redirect_to_login()
+
     payload = {
         "user": claims,
-        "access_token": result["access_token"],
+        "access_token": access_token,
         "refresh_token": result.get("refresh_token"),
         "id_token": result.get("id_token"),
         "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
     }
     cookie_value = config.manager.create_session_cookie(payload)
     response = HttpResponseRedirect(config.post_login_redirect)
-    _DjangoResponseAdapter(response).set_cookie(config.manager.cookie_name, cookie_value)
+    adapter = _DjangoResponseAdapter(response)
+    adapter.set_cookie(config.manager.cookie_name, cookie_value)
+    adapter.delete_cookie(_STATE_COOKIE_NAME)
     return response
 
 
@@ -219,11 +265,9 @@ def logout_view(request: HttpRequest) -> HttpResponse:
     cookie_value = request.COOKIES.get(config.manager.cookie_name)
     id_token = None
     if cookie_value:
-        try:
-            payload = decrypt_session(cookie_value, config.manager._secret)
+        payload = config.manager.read_session(cookie_value)
+        if payload:
             id_token = payload.get("id_token")
-        except InvalidSessionError:
-            pass  # nothing usable to hint with -- fall through to local-only redirect
 
     redirect_url = config.post_logout_redirect_uri
     if config.full_logout and id_token:

--- a/scalekit/frameworks/django.py
+++ b/scalekit/frameworks/django.py
@@ -196,6 +196,21 @@ def login_view(request: HttpRequest) -> HttpResponse:
     # offline_access is required to get a refresh_token back at all -- see
     # scalekit.frameworks.flask for the full explanation.
     options.scopes = ["openid", "profile", "email", "offline_access"]
+
+    # This view doubles as the dashboard-registered "Initiate Login URL" --
+    # see scalekit.frameworks.flask for the full reasoning.
+    idp_initiated_login = request.GET.get("idp_initiated_login")
+    if idp_initiated_login:
+        try:
+            claims = config.client.get_idp_initiated_login_claims(idp_initiated_login)
+            options.connection_id = claims.get("connection_id")
+            options.organization_id = claims.get("organization_id")
+            options.login_hint = claims.get("login_hint")
+        except Exception:
+            logger.exception(
+                "idp_initiated_login claim validation failed; falling back to normal login"
+            )
+
     # Bind this authorization request to the browser that started it, so
     # callback_view can reject a forged callback carrying an attacker's own
     # authorization code (CSRF) -- see scalekit.frameworks.flask.

--- a/scalekit/frameworks/fastapi.py
+++ b/scalekit/frameworks/fastapi.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 try:
     from fastapi import APIRouter, FastAPI, Request, Response
@@ -21,9 +22,11 @@ from scalekit.common.scalekit import (
     LogoutUrlOptions,
 )
 from scalekit.middleware.csrf_state import (
+    RETURN_TO_COOKIE_NAME,
     STATE_COOKIE_MAX_AGE,
     STATE_COOKIE_NAME,
     generate_state,
+    sanitize_return_to,
     verify_state,
 )
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
@@ -48,8 +51,13 @@ class _FastAPIRequestAdapter:
 class _FastAPIResponseAdapter:
     """ResponseAdapter implementation that mutates a Starlette/FastAPI Response in place."""
 
-    def __init__(self, response: Response):
+    def __init__(self, response: Response, *, secure: bool = True):
         self.response = response
+        # Default for callers that don't pass `secure` explicitly (e.g.
+        # SessionRefreshManager.apply(), which only knows the ResponseAdapter
+        # interface, not this app's cookie_secure setting) -- every
+        # ScalekitAuth call site now constructs this with secure=self.cookie_secure.
+        self._default_secure = secure
 
     def set_cookie(
         self,
@@ -57,7 +65,7 @@ class _FastAPIResponseAdapter:
         value: str,
         *,
         max_age: Optional[int] = None,
-        secure: bool = True,
+        secure: Optional[bool] = None,
         http_only: bool = True,
         same_site: str = "lax",
         domain: Optional[str] = None,
@@ -67,7 +75,7 @@ class _FastAPIResponseAdapter:
             key=name,
             value=value,
             max_age=max_age,
-            secure=secure,
+            secure=self._default_secure if secure is None else secure,
             httponly=http_only,
             samesite=same_site,
             domain=domain,
@@ -93,10 +101,18 @@ class _RequiresLoginRedirect(Exception):
     swallow -- the property this whole design exists to avoid.
     """
 
-    def __init__(self, location: str, clear_cookie: bool, cookie_name: str):
+    def __init__(
+        self,
+        location: str,
+        clear_cookie: bool,
+        cookie_name: str,
+        *,
+        return_to: Optional[str] = None,
+    ):
         self.location = location
         self.clear_cookie = clear_cookie
         self.cookie_name = cookie_name
+        self.return_to = return_to
 
 
 class ScalekitAuth:
@@ -116,7 +132,10 @@ class ScalekitAuth:
 
         @app.get("/account")
         async def account(user: dict = Depends(auth.requires_auth)):
-            return {"email": user["email"]}
+            # `user` is access-token claims, not a full id_token profile -- `sub`
+            # is always present; `email` only shows up if it's configured as a
+            # custom access-token claim in the Scalekit dashboard.
+            return {"sub": user["sub"]}
 
     Note: `requires_auth` sets the refreshed session cookie on the injected
     `response` parameter. If a protected endpoint returns a `Response`
@@ -137,6 +156,7 @@ class ScalekitAuth:
         redirect_uri: Optional[str] = None,
         cookie_encryption_secret: Optional[str] = None,
         cookie_name: str = DEFAULT_COOKIE_NAME,
+        cookie_secure: bool = True,
         login_path: str = "/login",
         callback_path: str = "/callback",
         logout_path: str = "/logout",
@@ -144,10 +164,20 @@ class ScalekitAuth:
         post_logout_redirect_uri: Optional[str] = None,
         full_logout: bool = True,
     ):
+        if not redirect_uri:
+            raise ValueError(
+                "redirect_uri is required. Pass the exact Redirect URI registered "
+                "for this app in the Scalekit dashboard (Authentication > Redirects), "
+                "e.g. redirect_uri=\"https://yourapp.com/callback\"."
+            )
         if client is None:
             client = ScalekitClient(env_url=env_url, client_id=client_id, client_secret=client_secret)
         self.client = client
         self.redirect_uri = redirect_uri
+        # Right default for production. Chrome (and some other browsers) silently
+        # drop a Secure cookie set over plain http://localhost, which looks like a
+        # session that never sticks -- set cookie_secure=False for local HTTP dev.
+        self.cookie_secure = cookie_secure
         self.login_path = login_path
         self.callback_path = callback_path
         self.logout_path = logout_path
@@ -173,10 +203,33 @@ class ScalekitAuth:
         app.add_exception_handler(_RequiresLoginRedirect, self._redirect_exception_handler)
 
     async def _redirect_exception_handler(self, request: Request, exc: _RequiresLoginRedirect):
-        response = RedirectResponse(exc.location, status_code=302)
+        location = exc.location
+        if exc.return_to:
+            location = f"{location}?returnTo={quote(exc.return_to, safe='')}"
+        response = RedirectResponse(location, status_code=302)
         if exc.clear_cookie:
-            _FastAPIResponseAdapter(response).delete_cookie(exc.cookie_name)
+            _FastAPIResponseAdapter(response, secure=self.cookie_secure).delete_cookie(exc.cookie_name)
         return response
+
+    def get_session(self, request: Request) -> Optional[Dict[str, Any]]:
+        """
+        Read-only session lookup -- for use outside a `requires_auth`-gated
+        endpoint (e.g. a homepage that wants to show a logged-in/logged-out
+        state without gating the whole route). Never refreshes or writes a
+        new cookie -- only `requires_auth` does that.
+
+        Returns `{"user": ..., "expires_at": ...}`, or `None` if there's no
+        valid session. `user` is the access-token claims (not tokens
+        themselves) -- this method never returns `access_token`,
+        `refresh_token`, or `id_token`.
+        """
+        cookie_value = request.cookies.get(self.manager.cookie_name)
+        if not cookie_value:
+            return None
+        payload = self.manager.read_session(cookie_value)
+        if payload is None:
+            return None
+        return {"user": payload.get("user"), "expires_at": payload.get("expires_at")}
 
     async def _login_view(self, request: Request):
         options = AuthorizationUrlOptions()
@@ -208,15 +261,24 @@ class ScalekitAuth:
         options.state = state
         url = await run_in_threadpool(self.client.get_authorization_url, self.redirect_uri, options)
         response = RedirectResponse(url, status_code=302)
-        _FastAPIResponseAdapter(response).set_cookie(
-            STATE_COOKIE_NAME, state, max_age=STATE_COOKIE_MAX_AGE
-        )
+        adapter = _FastAPIResponseAdapter(response, secure=self.cookie_secure)
+        adapter.set_cookie(STATE_COOKIE_NAME, state, max_age=STATE_COOKIE_MAX_AGE)
+
+        # Preserve the page the caller was trying to reach (set by
+        # requires_auth's redirect) so _callback_view can send them back there
+        # instead of the fixed post_login_redirect -- re-validated here since
+        # query strings are always attacker-influenceable.
+        return_to = sanitize_return_to(request.query_params.get("returnTo"))
+        if return_to:
+            adapter.set_cookie(RETURN_TO_COOKIE_NAME, return_to, max_age=STATE_COOKIE_MAX_AGE)
         return response
 
     async def _callback_view(self, request: Request):
         def _redirect_to_login():
             resp = RedirectResponse(self.login_path, status_code=302)
-            _FastAPIResponseAdapter(resp).delete_cookie(STATE_COOKIE_NAME)
+            adapter = _FastAPIResponseAdapter(resp, secure=self.cookie_secure)
+            adapter.delete_cookie(STATE_COOKIE_NAME)
+            adapter.delete_cookie(RETURN_TO_COOKIE_NAME)
             return resp
 
         # The provider redirects here with `error` (no `code`) if the user
@@ -259,10 +321,12 @@ class ScalekitAuth:
             logger.exception("login callback failed; redirecting to login")
             return _redirect_to_login()
 
-        response = RedirectResponse(self.post_login_redirect, status_code=302)
-        adapter = _FastAPIResponseAdapter(response)
+        return_to = sanitize_return_to(request.cookies.get(RETURN_TO_COOKIE_NAME))
+        response = RedirectResponse(return_to or self.post_login_redirect, status_code=302)
+        adapter = _FastAPIResponseAdapter(response, secure=self.cookie_secure)
         adapter.set_cookie(self.manager.cookie_name, cookie_value)
         adapter.delete_cookie(STATE_COOKIE_NAME)
+        adapter.delete_cookie(RETURN_TO_COOKIE_NAME)
         return response
 
     async def _logout_view(self, request: Request):
@@ -301,13 +365,22 @@ class ScalekitAuth:
         result = await run_in_threadpool(self.manager.check, _FastAPIRequestAdapter(request))
 
         if not result.authenticated:
+            # request.url.path + query preserves the page the caller was
+            # trying to reach so _login_view/_callback_view can send them
+            # back there instead of always landing on post_login_redirect.
+            current_path = request.url.path
+            if request.url.query:
+                current_path = f"{current_path}?{request.url.query}"
             raise _RequiresLoginRedirect(
                 location=self.login_path,
                 clear_cookie=result.should_clear_cookie,
                 cookie_name=self.manager.cookie_name,
+                return_to=current_path,
             )
 
         if result.new_cookie_value:
-            _FastAPIResponseAdapter(response).set_cookie(self.manager.cookie_name, result.new_cookie_value)
+            _FastAPIResponseAdapter(response, secure=self.cookie_secure).set_cookie(
+                self.manager.cookie_name, result.new_cookie_value
+            )
 
         return result.user

--- a/scalekit/frameworks/fastapi.py
+++ b/scalekit/frameworks/fastapi.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import secrets
+import logging
 import time
 from typing import Any, Dict, Optional
 
@@ -20,14 +20,16 @@ from scalekit.common.scalekit import (
     CodeAuthenticationOptions,
     LogoutUrlOptions,
 )
+from scalekit.middleware.csrf_state import (
+    STATE_COOKIE_MAX_AGE,
+    STATE_COOKIE_NAME,
+    generate_state,
+    verify_state,
+)
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
 from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
 
-# Short-lived cookie carrying the OAuth `state` value between /login and
-# /callback -- see scalekit.frameworks.flask for the full CSRF reasoning
-# (identical here, not framework-specific).
-_STATE_COOKIE_NAME = "sk_oauth_state"
-_STATE_COOKIE_MAX_AGE = 600  # 10 minutes
+logger = logging.getLogger("scalekit.frameworks.fastapi")
 
 
 class _FastAPIRequestAdapter:
@@ -185,19 +187,19 @@ class ScalekitAuth:
         # Bind this authorization request to the browser that started it, so
         # /callback can reject a forged callback carrying an attacker's own
         # authorization code (CSRF) -- see scalekit.frameworks.flask.
-        state = secrets.token_urlsafe(32)
+        state = generate_state()
         options.state = state
         url = await run_in_threadpool(self.client.get_authorization_url, self.redirect_uri, options)
         response = RedirectResponse(url, status_code=302)
         _FastAPIResponseAdapter(response).set_cookie(
-            _STATE_COOKIE_NAME, state, max_age=_STATE_COOKIE_MAX_AGE
+            STATE_COOKIE_NAME, state, max_age=STATE_COOKIE_MAX_AGE
         )
         return response
 
     async def _callback_view(self, request: Request):
         def _redirect_to_login():
             resp = RedirectResponse(self.login_path, status_code=302)
-            _FastAPIResponseAdapter(resp).delete_cookie(_STATE_COOKIE_NAME)
+            _FastAPIResponseAdapter(resp).delete_cookie(STATE_COOKIE_NAME)
             return resp
 
         # The provider redirects here with `error` (no `code`) if the user
@@ -208,13 +210,9 @@ class ScalekitAuth:
         if error or not code:
             return _redirect_to_login()
 
-        stored_state = request.cookies.get(_STATE_COOKIE_NAME)
+        stored_state = request.cookies.get(STATE_COOKIE_NAME)
         returned_state = request.query_params.get("state")
-        if (
-            not stored_state
-            or not returned_state
-            or not secrets.compare_digest(stored_state, returned_state)
-        ):
+        if not verify_state(stored_state, returned_state):
             # Missing or mismatched state -- this callback did not originate
             # from a /login this browser actually made. Refuse the exchange.
             return _redirect_to_login()
@@ -229,21 +227,25 @@ class ScalekitAuth:
             claims = await run_in_threadpool(
                 self.client.validate_access_token_and_get_claims, access_token
             )
+            payload = {
+                "user": claims,
+                "access_token": access_token,
+                "refresh_token": result.get("refresh_token"),
+                "id_token": result.get("id_token"),
+                "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
+            }
+            # create_session_cookie raises if the encrypted payload exceeds the
+            # browser cookie size limit -- must stay inside this try, not just
+            # the network calls above, or this view raises with no wrapper.
+            cookie_value = self.manager.create_session_cookie(payload)
         except Exception:
+            logger.exception("login callback failed; redirecting to login")
             return _redirect_to_login()
 
-        payload = {
-            "user": claims,
-            "access_token": access_token,
-            "refresh_token": result.get("refresh_token"),
-            "id_token": result.get("id_token"),
-            "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
-        }
-        cookie_value = self.manager.create_session_cookie(payload)
         response = RedirectResponse(self.post_login_redirect, status_code=302)
         adapter = _FastAPIResponseAdapter(response)
         adapter.set_cookie(self.manager.cookie_name, cookie_value)
-        adapter.delete_cookie(_STATE_COOKIE_NAME)
+        adapter.delete_cookie(STATE_COOKIE_NAME)
         return response
 
     async def _logout_view(self, request: Request):

--- a/scalekit/frameworks/fastapi.py
+++ b/scalekit/frameworks/fastapi.py
@@ -178,12 +178,29 @@ class ScalekitAuth:
             _FastAPIResponseAdapter(response).delete_cookie(exc.cookie_name)
         return response
 
-    async def _login_view(self):
+    async def _login_view(self, request: Request):
         options = AuthorizationUrlOptions()
         # offline_access is required to get a refresh_token back at all -- see
         # scalekit.frameworks.flask for the full explanation (same reasoning
         # applies here; the backend behavior isn't framework-specific).
         options.scopes = ["openid", "profile", "email", "offline_access"]
+
+        # This view doubles as the dashboard-registered "Initiate Login URL"
+        # -- see scalekit.frameworks.flask for the full reasoning.
+        idp_initiated_login = request.query_params.get("idp_initiated_login")
+        if idp_initiated_login:
+            try:
+                claims = await run_in_threadpool(
+                    self.client.get_idp_initiated_login_claims, idp_initiated_login
+                )
+                options.connection_id = claims.get("connection_id")
+                options.organization_id = claims.get("organization_id")
+                options.login_hint = claims.get("login_hint")
+            except Exception:
+                logger.exception(
+                    "idp_initiated_login claim validation failed; falling back to normal login"
+                )
+
         # Bind this authorization request to the browser that started it, so
         # /callback can reject a forged callback carrying an attacker's own
         # authorization code (CSRF) -- see scalekit.frameworks.flask.

--- a/scalekit/frameworks/fastapi.py
+++ b/scalekit/frameworks/fastapi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 import time
 from typing import Any, Dict, Optional
 
@@ -20,8 +21,13 @@ from scalekit.common.scalekit import (
     LogoutUrlOptions,
 )
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
-from scalekit.middleware.session_crypto import InvalidSessionError, decrypt_session
 from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
+
+# Short-lived cookie carrying the OAuth `state` value between /login and
+# /callback -- see scalekit.frameworks.flask for the full CSRF reasoning
+# (identical here, not framework-specific).
+_STATE_COOKIE_NAME = "sk_oauth_state"
+_STATE_COOKIE_MAX_AGE = 600  # 10 minutes
 
 
 class _FastAPIRequestAdapter:
@@ -109,6 +115,14 @@ class ScalekitAuth:
         @app.get("/account")
         async def account(user: dict = Depends(auth.requires_auth)):
             return {"email": user["email"]}
+
+    Note: `requires_auth` sets the refreshed session cookie on the injected
+    `response` parameter. If a protected endpoint returns a `Response`
+    instance directly instead of a plain value, FastAPI uses that returned
+    response instead of the injected one, and the refreshed cookie is
+    discarded. If you need to return a `Response` directly from a protected
+    endpoint, copy `response.raw_headers` (or re-apply the cookie) onto the
+    response you return.
     """
 
     def __init__(
@@ -168,40 +182,77 @@ class ScalekitAuth:
         # scalekit.frameworks.flask for the full explanation (same reasoning
         # applies here; the backend behavior isn't framework-specific).
         options.scopes = ["openid", "profile", "email", "offline_access"]
+        # Bind this authorization request to the browser that started it, so
+        # /callback can reject a forged callback carrying an attacker's own
+        # authorization code (CSRF) -- see scalekit.frameworks.flask.
+        state = secrets.token_urlsafe(32)
+        options.state = state
         url = await run_in_threadpool(self.client.get_authorization_url, self.redirect_uri, options)
-        return RedirectResponse(url, status_code=302)
+        response = RedirectResponse(url, status_code=302)
+        _FastAPIResponseAdapter(response).set_cookie(
+            _STATE_COOKIE_NAME, state, max_age=_STATE_COOKIE_MAX_AGE
+        )
+        return response
 
     async def _callback_view(self, request: Request):
+        def _redirect_to_login():
+            resp = RedirectResponse(self.login_path, status_code=302)
+            _FastAPIResponseAdapter(resp).delete_cookie(_STATE_COOKIE_NAME)
+            return resp
+
+        # The provider redirects here with `error` (no `code`) if the user
+        # cancels consent or the request is otherwise rejected -- never reflect
+        # error/error_description into the response, it's attacker-influenced.
+        error = request.query_params.get("error")
         code = request.query_params.get("code")
-        result = await run_in_threadpool(
-            self.client.authenticate_with_code, code, self.redirect_uri, CodeAuthenticationOptions()
-        )
-        # Access-token claims (not id_token claims) are the source of truth for
-        # `user` -- see scalekit.frameworks.flask for the full reasoning.
-        claims = await run_in_threadpool(
-            self.client.validate_access_token_and_get_claims, result["access_token"]
-        )
+        if error or not code:
+            return _redirect_to_login()
+
+        stored_state = request.cookies.get(_STATE_COOKIE_NAME)
+        returned_state = request.query_params.get("state")
+        if (
+            not stored_state
+            or not returned_state
+            or not secrets.compare_digest(stored_state, returned_state)
+        ):
+            # Missing or mismatched state -- this callback did not originate
+            # from a /login this browser actually made. Refuse the exchange.
+            return _redirect_to_login()
+
+        try:
+            result = await run_in_threadpool(
+                self.client.authenticate_with_code, code, self.redirect_uri, CodeAuthenticationOptions()
+            )
+            access_token = result["access_token"]
+            # Access-token claims (not id_token claims) are the source of truth for
+            # `user` -- see scalekit.frameworks.flask for the full reasoning.
+            claims = await run_in_threadpool(
+                self.client.validate_access_token_and_get_claims, access_token
+            )
+        except Exception:
+            return _redirect_to_login()
+
         payload = {
             "user": claims,
-            "access_token": result["access_token"],
+            "access_token": access_token,
             "refresh_token": result.get("refresh_token"),
             "id_token": result.get("id_token"),
             "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
         }
         cookie_value = self.manager.create_session_cookie(payload)
         response = RedirectResponse(self.post_login_redirect, status_code=302)
-        _FastAPIResponseAdapter(response).set_cookie(self.manager.cookie_name, cookie_value)
+        adapter = _FastAPIResponseAdapter(response)
+        adapter.set_cookie(self.manager.cookie_name, cookie_value)
+        adapter.delete_cookie(_STATE_COOKIE_NAME)
         return response
 
     async def _logout_view(self, request: Request):
         cookie_value = request.cookies.get(self.manager.cookie_name)
         id_token = None
         if cookie_value:
-            try:
-                payload = decrypt_session(cookie_value, self.manager._secret)
+            payload = self.manager.read_session(cookie_value)
+            if payload:
                 id_token = payload.get("id_token")
-            except InvalidSessionError:
-                pass  # nothing usable to hint with -- fall through to local-only redirect
 
         redirect_url = self.post_logout_redirect_uri
         if self.full_logout and id_token:
@@ -220,7 +271,7 @@ class ScalekitAuth:
         _FastAPIResponseAdapter(response).delete_cookie(self.manager.cookie_name)
         return response
 
-    async def requires_auth(self, request: Request, response: Response) -> Dict[str, Any]:
+    async def requires_auth(self, request: Request, response: Response) -> Optional[Dict[str, Any]]:
         """
         FastAPI dependency: `user: dict = Depends(auth.requires_auth)`.
 

--- a/scalekit/frameworks/fastapi.py
+++ b/scalekit/frameworks/fastapi.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+try:
+    from fastapi import APIRouter, FastAPI, Request, Response
+    from fastapi.responses import RedirectResponse
+    from starlette.concurrency import run_in_threadpool
+except ImportError as exc:  # pragma: no cover -- exercised only without the extra installed
+    raise ImportError(
+        "FastAPI integration requires the 'fastapi' extra: "
+        "pip install scalekit-sdk-python[fastapi]"
+    ) from exc
+
+from scalekit.client import ScalekitClient
+from scalekit.common.scalekit import (
+    AuthorizationUrlOptions,
+    CodeAuthenticationOptions,
+    LogoutUrlOptions,
+)
+from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
+from scalekit.middleware.session_crypto import InvalidSessionError, decrypt_session
+from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
+
+
+class _FastAPIRequestAdapter:
+    """RequestAdapter implementation backed by a Starlette/FastAPI Request."""
+
+    def __init__(self, request: Request):
+        self._request = request
+
+    def get_cookie(self, name: str) -> Optional[str]:
+        return self._request.cookies.get(name)
+
+    def get_request_url(self) -> str:
+        return str(self._request.url)
+
+
+class _FastAPIResponseAdapter:
+    """ResponseAdapter implementation that mutates a Starlette/FastAPI Response in place."""
+
+    def __init__(self, response: Response):
+        self.response = response
+
+    def set_cookie(
+        self,
+        name: str,
+        value: str,
+        *,
+        max_age: Optional[int] = None,
+        secure: bool = True,
+        http_only: bool = True,
+        same_site: str = "lax",
+        domain: Optional[str] = None,
+        path: str = "/",
+    ) -> None:
+        self.response.set_cookie(
+            key=name,
+            value=value,
+            max_age=max_age,
+            secure=secure,
+            httponly=http_only,
+            samesite=same_site,
+            domain=domain,
+            path=path,
+        )
+
+    def delete_cookie(
+        self, name: str, *, path: str = "/", domain: Optional[str] = None
+    ) -> None:
+        self.response.delete_cookie(key=name, path=path, domain=domain)
+
+
+class _RequiresLoginRedirect(Exception):
+    """
+    Internal signal raised by `requires_auth` when there's no valid session.
+
+    FastAPI dependencies can't directly return an alternate Response the way a
+    Flask decorator can wrap a whole view -- raising this and handling it via
+    an app-level exception handler (registered by `ScalekitAuth.install`) is
+    what lets "no valid session" produce a real 302 redirect instead of the
+    JSON 401 a raised HTTPException would otherwise produce. That JSON-401
+    default is exactly the failure mode a background fetch/XHR would silently
+    swallow -- the property this whole design exists to avoid.
+    """
+
+    def __init__(self, location: str, clear_cookie: bool, cookie_name: str):
+        self.location = location
+        self.clear_cookie = clear_cookie
+        self.cookie_name = cookie_name
+
+
+class ScalekitAuth:
+    """
+    FastAPI integration wiring Scalekit Full Stack Auth with the same secure
+    defaults as the Flask extension: encrypted session cookie, transparent
+    token refresh, full logout via id_token_hint. Protect routes with the
+    `requires_auth` dependency -- FastAPI's idiomatic protection mechanism is
+    `Depends()`, not a decorator:
+
+        auth = ScalekitAuth(
+            client_id=..., client_secret=..., env_url=...,
+            redirect_uri="https://myapp.com/callback",
+            cookie_encryption_secret=...,
+        )
+        auth.install(app)
+
+        @app.get("/account")
+        async def account(user: dict = Depends(auth.requires_auth)):
+            return {"email": user["email"]}
+    """
+
+    def __init__(
+        self,
+        *,
+        client: Optional[ScalekitClient] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        env_url: Optional[str] = None,
+        redirect_uri: Optional[str] = None,
+        cookie_encryption_secret: Optional[str] = None,
+        cookie_name: str = DEFAULT_COOKIE_NAME,
+        login_path: str = "/login",
+        callback_path: str = "/callback",
+        logout_path: str = "/logout",
+        post_login_redirect: str = "/",
+        post_logout_redirect_uri: Optional[str] = None,
+        full_logout: bool = True,
+    ):
+        if client is None:
+            client = ScalekitClient(env_url=env_url, client_id=client_id, client_secret=client_secret)
+        self.client = client
+        self.redirect_uri = redirect_uri
+        self.login_path = login_path
+        self.callback_path = callback_path
+        self.logout_path = logout_path
+        self.post_login_redirect = post_login_redirect
+        self.post_logout_redirect_uri = post_logout_redirect_uri or post_login_redirect
+        self.full_logout = full_logout
+
+        # Raises immediately if cookie_encryption_secret is missing -- see
+        # SessionRefreshManager and scalekit.middleware.session_crypto for why
+        # there is intentionally no default.
+        self.manager = SessionRefreshManager(
+            self.client, cookie_encryption_secret, cookie_name=cookie_name
+        )
+
+        self.router = APIRouter()
+        self.router.add_api_route(self.login_path, self._login_view, methods=["GET"])
+        self.router.add_api_route(self.callback_path, self._callback_view, methods=["GET"])
+        self.router.add_api_route(self.logout_path, self._logout_view, methods=["GET"])
+
+    def install(self, app: FastAPI) -> None:
+        """Register the login/callback/logout routes and the redirect exception handler."""
+        app.include_router(self.router)
+        app.add_exception_handler(_RequiresLoginRedirect, self._redirect_exception_handler)
+
+    async def _redirect_exception_handler(self, request: Request, exc: _RequiresLoginRedirect):
+        response = RedirectResponse(exc.location, status_code=302)
+        if exc.clear_cookie:
+            _FastAPIResponseAdapter(response).delete_cookie(exc.cookie_name)
+        return response
+
+    async def _login_view(self):
+        options = AuthorizationUrlOptions()
+        # offline_access is required to get a refresh_token back at all -- see
+        # scalekit.frameworks.flask for the full explanation (same reasoning
+        # applies here; the backend behavior isn't framework-specific).
+        options.scopes = ["openid", "profile", "email", "offline_access"]
+        url = await run_in_threadpool(self.client.get_authorization_url, self.redirect_uri, options)
+        return RedirectResponse(url, status_code=302)
+
+    async def _callback_view(self, request: Request):
+        code = request.query_params.get("code")
+        result = await run_in_threadpool(
+            self.client.authenticate_with_code, code, self.redirect_uri, CodeAuthenticationOptions()
+        )
+        # Access-token claims (not id_token claims) are the source of truth for
+        # `user` -- see scalekit.frameworks.flask for the full reasoning.
+        claims = await run_in_threadpool(
+            self.client.validate_access_token_and_get_claims, result["access_token"]
+        )
+        payload = {
+            "user": claims,
+            "access_token": result["access_token"],
+            "refresh_token": result.get("refresh_token"),
+            "id_token": result.get("id_token"),
+            "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
+        }
+        cookie_value = self.manager.create_session_cookie(payload)
+        response = RedirectResponse(self.post_login_redirect, status_code=302)
+        _FastAPIResponseAdapter(response).set_cookie(self.manager.cookie_name, cookie_value)
+        return response
+
+    async def _logout_view(self, request: Request):
+        cookie_value = request.cookies.get(self.manager.cookie_name)
+        id_token = None
+        if cookie_value:
+            try:
+                payload = decrypt_session(cookie_value, self.manager._secret)
+                id_token = payload.get("id_token")
+            except InvalidSessionError:
+                pass  # nothing usable to hint with -- fall through to local-only redirect
+
+        redirect_url = self.post_logout_redirect_uri
+        if self.full_logout and id_token:
+            # Scalekit requires an absolute, dashboard-registered post-logout
+            # redirect URI -- absolutize a relative default against the
+            # current request's host, same as the Flask adapter.
+            absolute_redirect_uri = self.post_logout_redirect_uri
+            if not absolute_redirect_uri.startswith(("http://", "https://")):
+                absolute_redirect_uri = str(request.base_url).rstrip("/") + absolute_redirect_uri
+            options = LogoutUrlOptions()
+            options.id_token_hint = id_token
+            options.post_logout_redirect_uri = absolute_redirect_uri
+            redirect_url = await run_in_threadpool(self.client.get_logout_url, options)
+
+        response = RedirectResponse(redirect_url, status_code=302)
+        _FastAPIResponseAdapter(response).delete_cookie(self.manager.cookie_name)
+        return response
+
+    async def requires_auth(self, request: Request, response: Response) -> Dict[str, Any]:
+        """
+        FastAPI dependency: `user: dict = Depends(auth.requires_auth)`.
+
+        Session check/refresh runs in a thread pool since the underlying
+        client calls are blocking network I/O -- this avoids stalling the
+        event loop on every protected request.
+        """
+        result = await run_in_threadpool(self.manager.check, _FastAPIRequestAdapter(request))
+
+        if not result.authenticated:
+            raise _RequiresLoginRedirect(
+                location=self.login_path,
+                clear_cookie=result.should_clear_cookie,
+                cookie_name=self.manager.cookie_name,
+            )
+
+        if result.new_cookie_value:
+            _FastAPIResponseAdapter(response).set_cookie(self.manager.cookie_name, result.new_cookie_value)
+
+        return result.user

--- a/scalekit/frameworks/flask.py
+++ b/scalekit/frameworks/flask.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import time
+from functools import wraps
+from typing import Any, Callable, Dict, Optional
+
+try:
+    from flask import Flask, Response, g
+    from flask import redirect as flask_redirect
+    from flask import request as flask_request
+except ImportError as exc:  # pragma: no cover -- exercised only without the extra installed
+    raise ImportError(
+        "Flask integration requires the 'flask' extra: "
+        "pip install scalekit-sdk-python[flask]"
+    ) from exc
+
+from scalekit.client import ScalekitClient
+from scalekit.common.scalekit import AuthorizationUrlOptions, CodeAuthenticationOptions
+from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
+from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
+
+
+class _FlaskRequestAdapter:
+    """RequestAdapter implementation backed by Flask's request context."""
+
+    def get_cookie(self, name: str) -> Optional[str]:
+        return flask_request.cookies.get(name)
+
+    def get_request_url(self) -> str:
+        return flask_request.url
+
+
+class _FlaskResponseAdapter:
+    """ResponseAdapter implementation that mutates a Flask Response in place."""
+
+    def __init__(self, response: Response):
+        self.response = response
+
+    def set_cookie(
+        self,
+        name: str,
+        value: str,
+        *,
+        max_age: Optional[int] = None,
+        secure: bool = True,
+        http_only: bool = True,
+        same_site: str = "Lax",
+        domain: Optional[str] = None,
+        path: str = "/",
+    ) -> None:
+        self.response.set_cookie(
+            name,
+            value,
+            max_age=max_age,
+            secure=secure,
+            httponly=http_only,
+            samesite=same_site,
+            domain=domain,
+            path=path,
+        )
+
+    def delete_cookie(
+        self, name: str, *, path: str = "/", domain: Optional[str] = None
+    ) -> None:
+        self.response.delete_cookie(name, path=path, domain=domain)
+
+
+class ScalekitAuth:
+    """
+    Flask extension wiring Scalekit Full Stack Auth into a Flask app with
+    secure defaults out of the box: an encrypted session cookie, transparent
+    token refresh on every request, and a `requires_auth` decorator to
+    protect routes -- so the developer never hand-rolls cookie attributes,
+    refresh timing, or expired/invalid/missing-session branching themselves.
+
+    Usage:
+        auth = ScalekitAuth(
+            app,
+            client_id=..., client_secret=..., env_url=...,
+            redirect_uri="https://myapp.com/callback",
+            cookie_encryption_secret=...,
+        )
+
+        @app.route("/account")
+        @auth.requires_auth
+        def account():
+            return f"Hello {auth.current_user['email']}"
+    """
+
+    def __init__(
+        self,
+        app: Optional[Flask] = None,
+        *,
+        client: Optional[ScalekitClient] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
+        env_url: Optional[str] = None,
+        redirect_uri: Optional[str] = None,
+        cookie_encryption_secret: Optional[str] = None,
+        cookie_name: str = DEFAULT_COOKIE_NAME,
+        login_path: str = "/login",
+        callback_path: str = "/callback",
+        logout_path: str = "/logout",
+        post_login_redirect: str = "/",
+    ):
+        if client is None:
+            client = ScalekitClient(env_url=env_url, client_id=client_id, client_secret=client_secret)
+        self.client = client
+        self.redirect_uri = redirect_uri
+        self.login_path = login_path
+        self.callback_path = callback_path
+        self.logout_path = logout_path
+        self.post_login_redirect = post_login_redirect
+
+        # Raises immediately if cookie_encryption_secret is missing -- see
+        # SessionRefreshManager and scalekit.middleware.session_crypto for why
+        # there is intentionally no default.
+        self.manager = SessionRefreshManager(
+            self.client, cookie_encryption_secret, cookie_name=cookie_name
+        )
+
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app: Flask) -> None:
+        app.add_url_rule(self.login_path, "scalekit_login", self._login_view)
+        app.add_url_rule(self.callback_path, "scalekit_callback", self._callback_view)
+        app.add_url_rule(self.logout_path, "scalekit_logout", self._logout_view)
+
+    @property
+    def current_user(self) -> Optional[Dict[str, Any]]:
+        return getattr(g, "scalekit_user", None)
+
+    def _login_view(self):
+        url = self.client.get_authorization_url(self.redirect_uri, AuthorizationUrlOptions())
+        return flask_redirect(url)
+
+    def _callback_view(self):
+        code = flask_request.args.get("code")
+        result = self.client.authenticate_with_code(
+            code, self.redirect_uri, CodeAuthenticationOptions()
+        )
+        payload = {
+            "user": result.get("user"),
+            "access_token": result["access_token"],
+            "refresh_token": result.get("refresh_token"),
+            "expires_at": time.time() + (result.get("expires_in") or 300),
+        }
+        cookie_value = self.manager.create_session_cookie(payload)
+        response = Response(status=302, headers={"Location": self.post_login_redirect})
+        adapter = _FlaskResponseAdapter(response)
+        adapter.set_cookie(self.manager.cookie_name, cookie_value)
+        return response
+
+    def _logout_view(self):
+        response = Response(status=302, headers={"Location": self.post_login_redirect})
+        _FlaskResponseAdapter(response).delete_cookie(self.manager.cookie_name)
+        return response
+
+    def requires_auth(self, view_func: Callable) -> Callable:
+        @wraps(view_func)
+        def wrapped(*args, **kwargs):
+            result = self.manager.check(_FlaskRequestAdapter())
+
+            if not result.authenticated:
+                response = Response(status=302, headers={"Location": self.login_path})
+                if result.should_clear_cookie:
+                    _FlaskResponseAdapter(response).delete_cookie(self.manager.cookie_name)
+                return response
+
+            g.scalekit_user = result.user
+            response = Response(response=view_func(*args, **kwargs))
+            self.manager.apply(result, _FlaskResponseAdapter(response))
+            return response
+
+        return wrapped

--- a/scalekit/frameworks/flask.py
+++ b/scalekit/frameworks/flask.py
@@ -15,8 +15,13 @@ except ImportError as exc:  # pragma: no cover -- exercised only without the ext
     ) from exc
 
 from scalekit.client import ScalekitClient
-from scalekit.common.scalekit import AuthorizationUrlOptions, CodeAuthenticationOptions
+from scalekit.common.scalekit import (
+    AuthorizationUrlOptions,
+    CodeAuthenticationOptions,
+    LogoutUrlOptions,
+)
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
+from scalekit.middleware.session_crypto import InvalidSessionError, decrypt_session
 from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
 
 
@@ -102,6 +107,8 @@ class ScalekitAuth:
         callback_path: str = "/callback",
         logout_path: str = "/logout",
         post_login_redirect: str = "/",
+        post_logout_redirect_uri: Optional[str] = None,
+        full_logout: bool = True,
     ):
         if client is None:
             client = ScalekitClient(env_url=env_url, client_id=client_id, client_secret=client_secret)
@@ -111,6 +118,17 @@ class ScalekitAuth:
         self.callback_path = callback_path
         self.logout_path = logout_path
         self.post_login_redirect = post_login_redirect
+        # Must be separately allow-listed in the Scalekit dashboard (Authentication >
+        # Redirects > Post Logout URL) -- it's a different allow-list than the
+        # OAuth redirect_uri, so this is intentionally not just reused from
+        # post_login_redirect even though it defaults to the same value.
+        self.post_logout_redirect_uri = post_logout_redirect_uri or post_login_redirect
+        # Default to full logout (end the Scalekit-side session too, via
+        # id_token_hint) rather than local-only -- local-only silently leaves the
+        # user's Scalekit session alive, so a subsequent /login silently
+        # re-authenticates them with no visible login step at all, which is a
+        # confusing default for most apps. Set full_logout=False to opt out.
+        self.full_logout = full_logout
 
         # Raises immediately if cookie_encryption_secret is missing -- see
         # SessionRefreshManager and scalekit.middleware.session_crypto for why
@@ -132,7 +150,14 @@ class ScalekitAuth:
         return getattr(g, "scalekit_user", None)
 
     def _login_view(self):
-        url = self.client.get_authorization_url(self.redirect_uri, AuthorizationUrlOptions())
+        options = AuthorizationUrlOptions()
+        # offline_access is required to get a refresh_token back at all -- without
+        # it, Scalekit only issues an access_token and transparent refresh has
+        # nothing to work with (confirmed: a normal FSA client does NOT get
+        # offline_access added automatically -- that auto-add only applies to
+        # MCP/agent clients on the backend).
+        options.scopes = ["openid", "profile", "email", "offline_access"]
+        url = self.client.get_authorization_url(self.redirect_uri, options)
         return flask_redirect(url)
 
     def _callback_view(self):
@@ -140,11 +165,18 @@ class ScalekitAuth:
         result = self.client.authenticate_with_code(
             code, self.redirect_uri, CodeAuthenticationOptions()
         )
+        # Access-token claims (not id_token claims) are the source of truth for
+        # `user` -- customers can configure custom access-token claims in the
+        # Scalekit dashboard, and this is also what stays fresh on every refresh
+        # (see SessionRefreshManager._refresh). id_token is kept separately, only
+        # for use as id_token_hint on logout.
+        claims = self.client.validate_access_token_and_get_claims(result["access_token"])
         payload = {
-            "user": result.get("user"),
+            "user": claims,
             "access_token": result["access_token"],
             "refresh_token": result.get("refresh_token"),
-            "expires_at": time.time() + (result.get("expires_in") or 300),
+            "id_token": result.get("id_token"),
+            "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
         }
         cookie_value = self.manager.create_session_cookie(payload)
         response = Response(status=302, headers={"Location": self.post_login_redirect})
@@ -153,7 +185,33 @@ class ScalekitAuth:
         return response
 
     def _logout_view(self):
-        response = Response(status=302, headers={"Location": self.post_login_redirect})
+        cookie_value = flask_request.cookies.get(self.manager.cookie_name)
+        id_token = None
+        if cookie_value:
+            try:
+                payload = decrypt_session(cookie_value, self.manager._secret)
+                id_token = payload.get("id_token")
+            except InvalidSessionError:
+                pass  # nothing usable to hint with -- fall through to local-only redirect
+
+        redirect_url = self.post_logout_redirect_uri
+        if self.full_logout and id_token:
+            # Scalekit requires an absolute, dashboard-registered post-logout
+            # redirect URI (a relative path like "/" is rejected as
+            # invalid_request) -- absolutize it against the current request's
+            # host so a developer can still just pass a simple path.
+            absolute_redirect_uri = self.post_logout_redirect_uri
+            if not absolute_redirect_uri.startswith(("http://", "https://")):
+                absolute_redirect_uri = flask_request.host_url.rstrip("/") + absolute_redirect_uri
+            options = LogoutUrlOptions()
+            options.id_token_hint = id_token
+            options.post_logout_redirect_uri = absolute_redirect_uri
+            # A real top-level redirect to Scalekit's own domain is required here --
+            # same reason a background fetch/XHR can't do this: Scalekit needs the
+            # request to actually carry its own session cookie to end that session.
+            redirect_url = self.client.get_logout_url(options)
+
+        response = Response(status=302, headers={"Location": redirect_url})
         _FlaskResponseAdapter(response).delete_cookie(self.manager.cookie_name)
         return response
 

--- a/scalekit/frameworks/flask.py
+++ b/scalekit/frameworks/flask.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import secrets
 import time
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
 
 try:
-    from flask import Flask, Response, g
+    from flask import Flask, Response, g, make_response
     from flask import redirect as flask_redirect
     from flask import request as flask_request
 except ImportError as exc:  # pragma: no cover -- exercised only without the extra installed
@@ -21,8 +22,14 @@ from scalekit.common.scalekit import (
     LogoutUrlOptions,
 )
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
-from scalekit.middleware.session_crypto import InvalidSessionError, decrypt_session
 from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
+
+# Short-lived cookie carrying the OAuth `state` value between /login and
+# /callback, so /callback can verify the provider's callback wasn't forged
+# (CSRF: an attacker's own authorization code smuggled into a victim's
+# browser session) -- see _login_view/_callback_view.
+_STATE_COOKIE_NAME = "sk_oauth_state"
+_STATE_COOKIE_MAX_AGE = 600  # 10 minutes -- generous for a slow login, still short-lived
 
 
 class _FlaskRequestAdapter:
@@ -157,23 +164,60 @@ class ScalekitAuth:
         # offline_access added automatically -- that auto-add only applies to
         # MCP/agent clients on the backend).
         options.scopes = ["openid", "profile", "email", "offline_access"]
+        # Bind this authorization request to the browser that started it, so
+        # /callback can reject a forged callback carrying an attacker's own
+        # authorization code (CSRF).
+        state = secrets.token_urlsafe(32)
+        options.state = state
         url = self.client.get_authorization_url(self.redirect_uri, options)
-        return flask_redirect(url)
+        response = Response(status=302, headers={"Location": url})
+        _FlaskResponseAdapter(response).set_cookie(
+            _STATE_COOKIE_NAME, state, max_age=_STATE_COOKIE_MAX_AGE
+        )
+        return response
 
     def _callback_view(self):
+        def _redirect_to_login():
+            resp = Response(status=302, headers={"Location": self.login_path})
+            _FlaskResponseAdapter(resp).delete_cookie(_STATE_COOKIE_NAME)
+            return resp
+
+        # The provider redirects here with `error` (no `code`) if the user
+        # cancels consent or the request is otherwise rejected -- never reflect
+        # error/error_description into the response, it's attacker-influenced.
+        error = flask_request.args.get("error")
         code = flask_request.args.get("code")
-        result = self.client.authenticate_with_code(
-            code, self.redirect_uri, CodeAuthenticationOptions()
-        )
-        # Access-token claims (not id_token claims) are the source of truth for
-        # `user` -- customers can configure custom access-token claims in the
-        # Scalekit dashboard, and this is also what stays fresh on every refresh
-        # (see SessionRefreshManager._refresh). id_token is kept separately, only
-        # for use as id_token_hint on logout.
-        claims = self.client.validate_access_token_and_get_claims(result["access_token"])
+        if error or not code:
+            return _redirect_to_login()
+
+        stored_state = flask_request.cookies.get(_STATE_COOKIE_NAME)
+        returned_state = flask_request.args.get("state")
+        if (
+            not stored_state
+            or not returned_state
+            or not secrets.compare_digest(stored_state, returned_state)
+        ):
+            # Missing or mismatched state -- this callback did not originate
+            # from a /login this browser actually made. Refuse the exchange.
+            return _redirect_to_login()
+
+        try:
+            result = self.client.authenticate_with_code(
+                code, self.redirect_uri, CodeAuthenticationOptions()
+            )
+            access_token = result["access_token"]
+            # Access-token claims (not id_token claims) are the source of truth for
+            # `user` -- customers can configure custom access-token claims in the
+            # Scalekit dashboard, and this is also what stays fresh on every refresh
+            # (see SessionRefreshManager._refresh). id_token is kept separately, only
+            # for use as id_token_hint on logout.
+            claims = self.client.validate_access_token_and_get_claims(access_token)
+        except Exception:
+            return _redirect_to_login()
+
         payload = {
             "user": claims,
-            "access_token": result["access_token"],
+            "access_token": access_token,
             "refresh_token": result.get("refresh_token"),
             "id_token": result.get("id_token"),
             "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
@@ -182,17 +226,16 @@ class ScalekitAuth:
         response = Response(status=302, headers={"Location": self.post_login_redirect})
         adapter = _FlaskResponseAdapter(response)
         adapter.set_cookie(self.manager.cookie_name, cookie_value)
+        adapter.delete_cookie(_STATE_COOKIE_NAME)
         return response
 
     def _logout_view(self):
         cookie_value = flask_request.cookies.get(self.manager.cookie_name)
         id_token = None
         if cookie_value:
-            try:
-                payload = decrypt_session(cookie_value, self.manager._secret)
+            payload = self.manager.read_session(cookie_value)
+            if payload:
                 id_token = payload.get("id_token")
-            except InvalidSessionError:
-                pass  # nothing usable to hint with -- fall through to local-only redirect
 
         redirect_url = self.post_logout_redirect_uri
         if self.full_logout and id_token:
@@ -227,7 +270,11 @@ class ScalekitAuth:
                 return response
 
             g.scalekit_user = result.user
-            response = Response(response=view_func(*args, **kwargs))
+            # make_response applies Flask's normal view-return handling (dict ->
+            # JSON, (body, status) tuples, an existing Response passed through
+            # unchanged, ...) -- a bare Response(response=...) bypasses all of
+            # that and silently mangles anything but a plain string return.
+            response = make_response(view_func(*args, **kwargs))
             self.manager.apply(result, _FlaskResponseAdapter(response))
             return response
 

--- a/scalekit/frameworks/flask.py
+++ b/scalekit/frameworks/flask.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import secrets
+import logging
 import time
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
@@ -21,15 +21,16 @@ from scalekit.common.scalekit import (
     CodeAuthenticationOptions,
     LogoutUrlOptions,
 )
+from scalekit.middleware.csrf_state import (
+    STATE_COOKIE_MAX_AGE,
+    STATE_COOKIE_NAME,
+    generate_state,
+    verify_state,
+)
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
 from scalekit.middleware.session_manager import DEFAULT_COOKIE_NAME, SessionRefreshManager
 
-# Short-lived cookie carrying the OAuth `state` value between /login and
-# /callback, so /callback can verify the provider's callback wasn't forged
-# (CSRF: an attacker's own authorization code smuggled into a victim's
-# browser session) -- see _login_view/_callback_view.
-_STATE_COOKIE_NAME = "sk_oauth_state"
-_STATE_COOKIE_MAX_AGE = 600  # 10 minutes -- generous for a slow login, still short-lived
+logger = logging.getLogger("scalekit.frameworks.flask")
 
 
 class _FlaskRequestAdapter:
@@ -167,19 +168,19 @@ class ScalekitAuth:
         # Bind this authorization request to the browser that started it, so
         # /callback can reject a forged callback carrying an attacker's own
         # authorization code (CSRF).
-        state = secrets.token_urlsafe(32)
+        state = generate_state()
         options.state = state
         url = self.client.get_authorization_url(self.redirect_uri, options)
         response = Response(status=302, headers={"Location": url})
         _FlaskResponseAdapter(response).set_cookie(
-            _STATE_COOKIE_NAME, state, max_age=_STATE_COOKIE_MAX_AGE
+            STATE_COOKIE_NAME, state, max_age=STATE_COOKIE_MAX_AGE
         )
         return response
 
     def _callback_view(self):
         def _redirect_to_login():
             resp = Response(status=302, headers={"Location": self.login_path})
-            _FlaskResponseAdapter(resp).delete_cookie(_STATE_COOKIE_NAME)
+            _FlaskResponseAdapter(resp).delete_cookie(STATE_COOKIE_NAME)
             return resp
 
         # The provider redirects here with `error` (no `code`) if the user
@@ -190,13 +191,9 @@ class ScalekitAuth:
         if error or not code:
             return _redirect_to_login()
 
-        stored_state = flask_request.cookies.get(_STATE_COOKIE_NAME)
+        stored_state = flask_request.cookies.get(STATE_COOKIE_NAME)
         returned_state = flask_request.args.get("state")
-        if (
-            not stored_state
-            or not returned_state
-            or not secrets.compare_digest(stored_state, returned_state)
-        ):
+        if not verify_state(stored_state, returned_state):
             # Missing or mismatched state -- this callback did not originate
             # from a /login this browser actually made. Refuse the exchange.
             return _redirect_to_login()
@@ -212,21 +209,26 @@ class ScalekitAuth:
             # (see SessionRefreshManager._refresh). id_token is kept separately, only
             # for use as id_token_hint on logout.
             claims = self.client.validate_access_token_and_get_claims(access_token)
+            payload = {
+                "user": claims,
+                "access_token": access_token,
+                "refresh_token": result.get("refresh_token"),
+                "id_token": result.get("id_token"),
+                "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
+            }
+            # create_session_cookie raises if the encrypted payload exceeds the
+            # browser cookie size limit (e.g. several custom access-token claims
+            # configured) -- must stay inside this try, not just the network
+            # calls above, or this view raises with no wrapper around it.
+            cookie_value = self.manager.create_session_cookie(payload)
         except Exception:
+            logger.exception("login callback failed; redirecting to login")
             return _redirect_to_login()
 
-        payload = {
-            "user": claims,
-            "access_token": access_token,
-            "refresh_token": result.get("refresh_token"),
-            "id_token": result.get("id_token"),
-            "expires_at": claims.get("exp", time.time() + (result.get("expires_in") or 300)),
-        }
-        cookie_value = self.manager.create_session_cookie(payload)
         response = Response(status=302, headers={"Location": self.post_login_redirect})
         adapter = _FlaskResponseAdapter(response)
         adapter.set_cookie(self.manager.cookie_name, cookie_value)
-        adapter.delete_cookie(_STATE_COOKIE_NAME)
+        adapter.delete_cookie(STATE_COOKIE_NAME)
         return response
 
     def _logout_view(self):

--- a/scalekit/frameworks/flask.py
+++ b/scalekit/frameworks/flask.py
@@ -165,6 +165,27 @@ class ScalekitAuth:
         # offline_access added automatically -- that auto-add only applies to
         # MCP/agent clients on the backend).
         options.scopes = ["openid", "profile", "email", "offline_access"]
+
+        # This view doubles as the dashboard-registered "Initiate Login URL":
+        # Scalekit lands users here (not /callback) for a bookmarked/direct
+        # login-page hit, an IdP portal tile, or an invite/magic link. If
+        # there's an active session at that moment, Scalekit attaches an
+        # idp_initiated_login JWT so the flow can jump straight to the
+        # right connection/org instead of a generic login. relay_state is
+        # intentionally not forwarded as our OAuth `state` -- we use our own
+        # random value for CSRF cookie-binding instead (see below).
+        idp_initiated_login = flask_request.args.get("idp_initiated_login")
+        if idp_initiated_login:
+            try:
+                claims = self.client.get_idp_initiated_login_claims(idp_initiated_login)
+                options.connection_id = claims.get("connection_id")
+                options.organization_id = claims.get("organization_id")
+                options.login_hint = claims.get("login_hint")
+            except Exception:
+                logger.exception(
+                    "idp_initiated_login claim validation failed; falling back to normal login"
+                )
+
         # Bind this authorization request to the browser that started it, so
         # /callback can reject a forged callback carrying an attacker's own
         # authorization code (CSRF).

--- a/scalekit/frameworks/flask.py
+++ b/scalekit/frameworks/flask.py
@@ -4,6 +4,7 @@ import logging
 import time
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
+from urllib.parse import quote
 
 try:
     from flask import Flask, Response, g, make_response
@@ -22,9 +23,11 @@ from scalekit.common.scalekit import (
     LogoutUrlOptions,
 )
 from scalekit.middleware.csrf_state import (
+    RETURN_TO_COOKIE_NAME,
     STATE_COOKIE_MAX_AGE,
     STATE_COOKIE_NAME,
     generate_state,
+    sanitize_return_to,
     verify_state,
 )
 from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
@@ -46,8 +49,13 @@ class _FlaskRequestAdapter:
 class _FlaskResponseAdapter:
     """ResponseAdapter implementation that mutates a Flask Response in place."""
 
-    def __init__(self, response: Response):
+    def __init__(self, response: Response, *, secure: bool = True):
         self.response = response
+        # Default for callers that don't pass `secure` explicitly (e.g.
+        # SessionRefreshManager.apply(), which only knows the ResponseAdapter
+        # interface, not this app's cookie_secure setting) -- every
+        # ScalekitAuth call site now constructs this with secure=self.cookie_secure.
+        self._default_secure = secure
 
     def set_cookie(
         self,
@@ -55,7 +63,7 @@ class _FlaskResponseAdapter:
         value: str,
         *,
         max_age: Optional[int] = None,
-        secure: bool = True,
+        secure: Optional[bool] = None,
         http_only: bool = True,
         same_site: str = "Lax",
         domain: Optional[str] = None,
@@ -65,7 +73,7 @@ class _FlaskResponseAdapter:
             name,
             value,
             max_age=max_age,
-            secure=secure,
+            secure=self._default_secure if secure is None else secure,
             httponly=http_only,
             samesite=same_site,
             domain=domain,
@@ -97,7 +105,10 @@ class ScalekitAuth:
         @app.route("/account")
         @auth.requires_auth
         def account():
-            return f"Hello {auth.current_user['email']}"
+            # `current_user` is access-token claims, not a full id_token profile --
+            # `sub` is always present; `email` only shows up if it's configured as
+            # a custom access-token claim in the Scalekit dashboard.
+            return f"Hello {auth.current_user['sub']}"
     """
 
     def __init__(
@@ -111,6 +122,7 @@ class ScalekitAuth:
         redirect_uri: Optional[str] = None,
         cookie_encryption_secret: Optional[str] = None,
         cookie_name: str = DEFAULT_COOKIE_NAME,
+        cookie_secure: bool = True,
         login_path: str = "/login",
         callback_path: str = "/callback",
         logout_path: str = "/logout",
@@ -118,10 +130,20 @@ class ScalekitAuth:
         post_logout_redirect_uri: Optional[str] = None,
         full_logout: bool = True,
     ):
+        if not redirect_uri:
+            raise ValueError(
+                "redirect_uri is required. Pass the exact Redirect URI registered "
+                "for this app in the Scalekit dashboard (Authentication > Redirects), "
+                "e.g. redirect_uri=\"https://yourapp.com/callback\"."
+            )
         if client is None:
             client = ScalekitClient(env_url=env_url, client_id=client_id, client_secret=client_secret)
         self.client = client
         self.redirect_uri = redirect_uri
+        # Right default for production. Chrome (and some other browsers) silently
+        # drop a Secure cookie set over plain http://localhost, which looks like a
+        # session that never sticks -- set cookie_secure=False for local HTTP dev.
+        self.cookie_secure = cookie_secure
         self.login_path = login_path
         self.callback_path = callback_path
         self.logout_path = logout_path
@@ -156,6 +178,26 @@ class ScalekitAuth:
     @property
     def current_user(self) -> Optional[Dict[str, Any]]:
         return getattr(g, "scalekit_user", None)
+
+    def get_session(self) -> Optional[Dict[str, Any]]:
+        """
+        Read-only session lookup -- for use outside a `requires_auth`-wrapped
+        view (e.g. a homepage that wants to show a logged-in/logged-out
+        state without gating the whole route). Never refreshes or writes a
+        new cookie -- only `requires_auth` does that.
+
+        Returns `{"user": ..., "expires_at": ...}`, or `None` if there's no
+        valid session. `user` is the access-token claims (not tokens
+        themselves) -- this method never returns `access_token`,
+        `refresh_token`, or `id_token`.
+        """
+        cookie_value = flask_request.cookies.get(self.manager.cookie_name)
+        if not cookie_value:
+            return None
+        payload = self.manager.read_session(cookie_value)
+        if payload is None:
+            return None
+        return {"user": payload.get("user"), "expires_at": payload.get("expires_at")}
 
     def _login_view(self):
         options = AuthorizationUrlOptions()
@@ -193,15 +235,26 @@ class ScalekitAuth:
         options.state = state
         url = self.client.get_authorization_url(self.redirect_uri, options)
         response = Response(status=302, headers={"Location": url})
-        _FlaskResponseAdapter(response).set_cookie(
-            STATE_COOKIE_NAME, state, max_age=STATE_COOKIE_MAX_AGE
-        )
+        adapter = _FlaskResponseAdapter(response, secure=self.cookie_secure)
+        adapter.set_cookie(STATE_COOKIE_NAME, state, max_age=STATE_COOKIE_MAX_AGE)
+
+        # Preserve the page the caller was trying to reach (set by
+        # requires_auth's redirect below) so _callback_view can send them
+        # back there instead of the fixed post_login_redirect -- re-validated
+        # here since query strings are always attacker-influenceable, even if
+        # requires_auth's own value was somehow bypassed by a direct
+        # /login?returnTo= hit.
+        return_to = sanitize_return_to(flask_request.args.get("returnTo"))
+        if return_to:
+            adapter.set_cookie(RETURN_TO_COOKIE_NAME, return_to, max_age=STATE_COOKIE_MAX_AGE)
         return response
 
     def _callback_view(self):
         def _redirect_to_login():
             resp = Response(status=302, headers={"Location": self.login_path})
-            _FlaskResponseAdapter(resp).delete_cookie(STATE_COOKIE_NAME)
+            adapter = _FlaskResponseAdapter(resp, secure=self.cookie_secure)
+            adapter.delete_cookie(STATE_COOKIE_NAME)
+            adapter.delete_cookie(RETURN_TO_COOKIE_NAME)
             return resp
 
         # The provider redirects here with `error` (no `code`) if the user
@@ -246,10 +299,14 @@ class ScalekitAuth:
             logger.exception("login callback failed; redirecting to login")
             return _redirect_to_login()
 
-        response = Response(status=302, headers={"Location": self.post_login_redirect})
-        adapter = _FlaskResponseAdapter(response)
+        return_to = sanitize_return_to(flask_request.cookies.get(RETURN_TO_COOKIE_NAME))
+        response = Response(
+            status=302, headers={"Location": return_to or self.post_login_redirect}
+        )
+        adapter = _FlaskResponseAdapter(response, secure=self.cookie_secure)
         adapter.set_cookie(self.manager.cookie_name, cookie_value)
         adapter.delete_cookie(STATE_COOKIE_NAME)
+        adapter.delete_cookie(RETURN_TO_COOKIE_NAME)
         return response
 
     def _logout_view(self):
@@ -287,7 +344,14 @@ class ScalekitAuth:
             result = self.manager.check(_FlaskRequestAdapter())
 
             if not result.authenticated:
-                response = Response(status=302, headers={"Location": self.login_path})
+                # Send the caller back to where they were trying to go once
+                # login completes, instead of always landing on
+                # post_login_redirect -- full_path includes the query string
+                # (e.g. "/account?tab=billing"), matching what sanitize_return_to
+                # validates on the receiving end (_login_view/_callback_view).
+                current_path = flask_request.full_path.rstrip("?")
+                location = f"{self.login_path}?returnTo={quote(current_path, safe='')}"
+                response = Response(status=302, headers={"Location": location})
                 if result.should_clear_cookie:
                     _FlaskResponseAdapter(response).delete_cookie(self.manager.cookie_name)
                 return response
@@ -298,7 +362,7 @@ class ScalekitAuth:
             # unchanged, ...) -- a bare Response(response=...) bypasses all of
             # that and silently mangles anything but a plain string return.
             response = make_response(view_func(*args, **kwargs))
-            self.manager.apply(result, _FlaskResponseAdapter(response))
+            self.manager.apply(result, _FlaskResponseAdapter(response, secure=self.cookie_secure))
             return response
 
         return wrapped

--- a/scalekit/middleware/csrf_state.py
+++ b/scalekit/middleware/csrf_state.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import secrets
+
+# Short-lived cookie carrying the OAuth `state` value between the login and
+# callback views, so the callback can verify the provider's callback wasn't
+# forged (CSRF: an attacker's own authorization code smuggled into a
+# victim's browser session). Shared by every framework extra -- not
+# framework-specific -- so a future fix here applies to all of them at once
+# instead of risking one adapter drifting out of sync with the others.
+STATE_COOKIE_NAME = "sk_oauth_state"
+STATE_COOKIE_MAX_AGE = 600  # 10 minutes -- generous for a slow login, still short-lived
+
+
+def generate_state() -> str:
+    """A fresh, random OAuth state value for the login view to issue."""
+    return secrets.token_urlsafe(32)
+
+
+def verify_state(stored_state, returned_state) -> bool:
+    """
+    True only if both values are present and match, using a timing-safe
+    comparison. Missing/mismatched state means this callback did not
+    originate from a login this browser actually made.
+    """
+    if not stored_state or not returned_state:
+        return False
+    return secrets.compare_digest(stored_state, returned_state)

--- a/scalekit/middleware/csrf_state.py
+++ b/scalekit/middleware/csrf_state.py
@@ -26,3 +26,32 @@ def verify_state(stored_state, returned_state) -> bool:
     if not stored_state or not returned_state:
         return False
     return secrets.compare_digest(stored_state, returned_state)
+
+
+# Short-lived cookie carrying a validated post-login redirect target between
+# the login and callback views, so `requires_auth`/`login_required` can send
+# a user back to the page they originally requested instead of a fixed
+# `post_login_redirect`. Shared by every framework extra, same as the OAuth
+# state cookie above.
+RETURN_TO_COOKIE_NAME = "sk_return_to"
+
+
+def sanitize_return_to(value):
+    """
+    Validates a candidate post-login redirect target, accepting only
+    same-origin relative paths. The value is attacker-influenceable (read
+    from a query string on the login redirect), so this is a real
+    open-redirect guard, not a cosmetic check: rejects absolute URLs
+    (`https://evil.com`), protocol-relative URLs (`//evil.com`), and
+    embedded tab/CR/LF characters -- browsers strip these during URL
+    parsing per the WHATWG URL spec, so a naive `startswith('/')` check
+    alone would let `"/\\t/evil.com"` normalize to the protocol-relative
+    `"//evil.com"` after the fact.
+    """
+    if not value:
+        return None
+    if not value.startswith("/") or value.startswith("//"):
+        return None
+    if any(ch in value for ch in ("\t", "\r", "\n")):
+        return None
+    return value

--- a/scalekit/middleware/protocol.py
+++ b/scalekit/middleware/protocol.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class RequestAdapter(Protocol):
+    """
+    Framework-agnostic view of an incoming HTTP request.
+
+    Framework integrations (Flask, FastAPI, Django, ...) implement this protocol
+    so the core session/refresh logic (`scalekit.middleware.session_manager`)
+    never imports a specific web framework.
+    """
+
+    def get_cookie(self, name: str) -> Optional[str]:
+        """Return the named cookie's value, or None if not present."""
+        ...
+
+    def get_request_url(self) -> str:
+        """Return the full URL of the current request."""
+        ...
+
+
+@runtime_checkable
+class ResponseAdapter(Protocol):
+    """
+    Framework-agnostic view of an outgoing HTTP response.
+
+    Cookie attributes are set here, not left to the developer -- callers of
+    `set_cookie` always get `HttpOnly`, `Secure`, and `SameSite` applied by the
+    adapter implementation, using the defaults documented on each parameter.
+    """
+
+    def set_cookie(
+        self,
+        name: str,
+        value: str,
+        *,
+        max_age: Optional[int] = None,
+        secure: bool = True,
+        http_only: bool = True,
+        same_site: str = "Lax",
+        domain: Optional[str] = None,
+        path: str = "/",
+    ) -> None:
+        ...
+
+    def delete_cookie(
+        self,
+        name: str,
+        *,
+        path: str = "/",
+        domain: Optional[str] = None,
+    ) -> None:
+        ...

--- a/scalekit/middleware/session_crypto.py
+++ b/scalekit/middleware/session_crypto.py
@@ -14,6 +14,11 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 _SESSION_FORMAT_VERSION = 1
 _NONCE_SIZE = 12  # bytes, standard for AES-GCM
 
+# Browsers silently drop cookies larger than ~4096 bytes (name + attributes
+# included), which would look like a random, unexplained logout. Fail loudly
+# instead so an oversized `user` claims payload is caught at encrypt time.
+_MAX_COOKIE_VALUE_BYTES = 3800
+
 # Fixed, non-secret HKDF salt/info: cookie_encryption_secret itself is expected to be a
 # high-entropy, developer-generated secret (not a low-entropy password), so a fast KDF
 # derivation is appropriate here -- this is not password storage.
@@ -59,7 +64,14 @@ def encrypt_session(payload: Dict[str, Any], secret: str) -> str:
     plaintext = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     ciphertext = AESGCM(key).encrypt(nonce, plaintext, None)
     raw = bytes([_SESSION_FORMAT_VERSION]) + nonce + ciphertext
-    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+    encoded = base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+    if len(encoded) > _MAX_COOKIE_VALUE_BYTES:
+        raise ValueError(
+            f"encrypted session is {len(encoded)} bytes, which exceeds the browser "
+            "cookie size limit; reduce the claims stored in the session (e.g. fewer "
+            "custom access-token claims)."
+        )
+    return encoded
 
 
 def decrypt_session(token: str, secret: str) -> Dict[str, Any]:

--- a/scalekit/middleware/session_crypto.py
+++ b/scalekit/middleware/session_crypto.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+from functools import lru_cache
 from typing import Any, Dict
 
 from cryptography.hazmat.primitives import hashes
@@ -42,7 +43,13 @@ class InvalidSessionError(Exception):
     """
 
 
+@lru_cache(maxsize=8)
 def _derive_key(secret: str) -> bytes:
+    # Cached: every encrypt_session()/decrypt_session() call on the request
+    # hot path was otherwise re-running a full HKDF-SHA256 derivation from
+    # the same static secret. A process normally uses one (or a handful,
+    # across key rotation) distinct secrets, so a small bounded cache is
+    # sufficient -- lru_cache never caches the ValueError below.
     if not secret:
         raise ValueError(_SECRET_HELP)
     hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=_HKDF_SALT, info=_HKDF_INFO)

--- a/scalekit/middleware/session_crypto.py
+++ b/scalekit/middleware/session_crypto.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+from typing import Any, Dict
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+# Bumped whenever the wire format changes. Older versions must fail gracefully
+# (InvalidSessionError, forcing re-login) rather than crash -- see decrypt_session.
+_SESSION_FORMAT_VERSION = 1
+_NONCE_SIZE = 12  # bytes, standard for AES-GCM
+
+# Fixed, non-secret HKDF salt/info: cookie_encryption_secret itself is expected to be a
+# high-entropy, developer-generated secret (not a low-entropy password), so a fast KDF
+# derivation is appropriate here -- this is not password storage.
+_HKDF_SALT = b"scalekit-session-v1"
+_HKDF_INFO = b"scalekit-encrypted-session"
+
+_SECRET_HELP = (
+    "cookie_encryption_secret is required. Generate a strong random secret, e.g.:\n"
+    '  python3 -c "import secrets; print(secrets.token_urlsafe(32))"\n'
+    "and keep it identical across every server instance -- there is intentionally no "
+    "default, since a shared default secret would let any deployment decrypt or forge "
+    "any other deployment's sessions."
+)
+
+
+class InvalidSessionError(Exception):
+    """
+    Raised when an encrypted session cannot be decrypted -- missing, malformed,
+    tampered with, or produced by an unsupported format version. Always raised
+    instead of returning a partially-decrypted or unauthenticated payload.
+    """
+
+
+def _derive_key(secret: str) -> bytes:
+    if not secret:
+        raise ValueError(_SECRET_HELP)
+    hkdf = HKDF(algorithm=hashes.SHA256(), length=32, salt=_HKDF_SALT, info=_HKDF_INFO)
+    return hkdf.derive(secret.encode("utf-8"))
+
+
+def encrypt_session(payload: Dict[str, Any], secret: str) -> str:
+    """
+    Encrypt a session payload (access_token, refresh_token, user claims,
+    expires_at, ...) into a single opaque, tamper-proof string suitable for
+    storing in a cookie.
+
+    :param payload: JSON-serializable session data.
+    :param secret: cookie_encryption_secret -- required, no default (see module docstring).
+    :returns: base64url-encoded, versioned ciphertext string.
+    """
+    key = _derive_key(secret)
+    nonce = os.urandom(_NONCE_SIZE)
+    plaintext = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext, None)
+    raw = bytes([_SESSION_FORMAT_VERSION]) + nonce + ciphertext
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decrypt_session(token: str, secret: str) -> Dict[str, Any]:
+    """
+    Decrypt a session cookie value produced by encrypt_session().
+
+    This only performs cryptographic verification -- it does NOT check
+    `expires_at`. Callers (SessionRefreshManager) decide what to do with an
+    expired-but-cryptographically-valid session (e.g. attempt a refresh using
+    the refresh_token still present in the payload).
+
+    :raises InvalidSessionError: if token is missing, malformed, tampered
+        with, or uses an unsupported format version. Never raises any other
+        exception type for these cases.
+    """
+    if not token:
+        raise InvalidSessionError("no session cookie provided")
+
+    key = _derive_key(secret)
+
+    try:
+        padding = "=" * (-len(token) % 4)
+        raw = base64.urlsafe_b64decode(token + padding)
+        if len(raw) < 1 + _NONCE_SIZE:
+            raise InvalidSessionError("session cookie is truncated")
+
+        version = raw[0]
+        if version != _SESSION_FORMAT_VERSION:
+            raise InvalidSessionError(f"unsupported session format version: {version}")
+
+        nonce = raw[1 : 1 + _NONCE_SIZE]
+        ciphertext = raw[1 + _NONCE_SIZE :]
+        plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
+        payload = json.loads(plaintext)
+    except InvalidSessionError:
+        raise
+    except Exception as exc:
+        raise InvalidSessionError(
+            "session cookie is invalid or has been tampered with"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise InvalidSessionError("decrypted session payload is not an object")
+
+    return payload

--- a/scalekit/middleware/session_manager.py
+++ b/scalekit/middleware/session_manager.py
@@ -102,8 +102,16 @@ class SessionRefreshManager:
     def _release_lock_ref(self, key: str) -> None:
         with self._locks_guard:
             entry = self._session_locks.get(key)
-            if entry is not None:
-                entry.ref_count -= 1
+            if entry is None:
+                return
+            entry.ref_count -= 1
+            if entry.ref_count <= 0 and key not in self._refresh_cache:
+                # No cache entry to preserve this lock for (a failed refresh is
+                # deliberately never cached -- see _refresh). Without this,
+                # _sweep_expired_locked would never remove it either, since it
+                # only considers keys present in _refresh_cache: every distinct
+                # refresh_token that ever fails would leak here forever.
+                self._session_locks.pop(key, None)
 
     def _sweep_expired_locked(self) -> None:
         """Evict refresh-cache/lock entries older than the TTL. Caller must hold no lock."""

--- a/scalekit/middleware/session_manager.py
+++ b/scalekit/middleware/session_manager.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from scalekit.middleware.protocol import RequestAdapter, ResponseAdapter
+from scalekit.middleware.session_crypto import (
+    InvalidSessionError,
+    decrypt_session,
+    encrypt_session,
+)
+
+DEFAULT_COOKIE_NAME = "sk_session"
+
+# Refresh a little before the stored expiry so a request doesn't race the exact
+# expiry instant against network latency to the token endpoint.
+_EXPIRY_LEEWAY_SECONDS = 10
+
+# How long a completed refresh outcome stays cached for singleflight coalescing
+# before it's swept. Comfortably longer than Scalekit's server-side refresh-token
+# rotation grace window (~30s) so same-process concurrent callers racing within
+# that window all land on the cached result rather than each hitting the network.
+_REFRESH_CACHE_TTL_SECONDS = 60
+
+
+@dataclass
+class SessionResult:
+    """Outcome of processing one request through SessionRefreshManager.check()."""
+
+    authenticated: bool
+    user: Optional[Dict[str, Any]] = None
+    new_cookie_value: Optional[str] = None  # set when the session was refreshed
+    should_clear_cookie: bool = False
+    reason: Optional[str] = None  # "no_session" | "invalid_session" | "refresh_failed"
+
+
+@dataclass
+class _RefreshOutcome:
+    session_result: SessionResult
+    created_at: float
+
+
+class SessionRefreshManager:
+    """
+    Framework-agnostic session state machine: decrypts the session cookie,
+    checks expiry, transparently refreshes via the Scalekit client when
+    needed, and reports what the framework adapter should do next (proceed /
+    set a new cookie / clear the cookie and redirect to login).
+
+    Concurrent requests for the *same* session within one process are
+    coalesced so only one actual refresh call is made -- see check().
+    Framework adapters (Flask, FastAPI, Django, ...) call `check()` on every
+    request and `apply()` to translate the result into cookie side effects on
+    the outgoing response; they never implement this state machine themselves.
+    """
+
+    def __init__(
+        self,
+        client: Any,  # scalekit.ScalekitClient -- untyped to avoid a circular import
+        cookie_encryption_secret: str,
+        cookie_name: str = DEFAULT_COOKIE_NAME,
+    ):
+        if not cookie_encryption_secret:
+            raise ValueError(
+                "cookie_encryption_secret is required. Generate a strong random "
+                'secret, e.g. `python3 -c "import secrets; print(secrets.token_urlsafe(32))"`, '
+                "and keep it identical across every server instance -- there is "
+                "intentionally no default, since a shared default secret would let "
+                "any deployment decrypt or forge any other deployment's sessions."
+            )
+        self._client = client
+        self._secret = cookie_encryption_secret
+        self.cookie_name = cookie_name
+
+        self._locks_guard = threading.Lock()
+        self._session_locks: Dict[str, threading.Lock] = {}
+        self._refresh_cache: Dict[str, _RefreshOutcome] = {}
+
+    def _lock_for(self, key: str) -> threading.Lock:
+        with self._locks_guard:
+            lock = self._session_locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                self._session_locks[key] = lock
+            return lock
+
+    def _sweep_expired_locked(self) -> None:
+        """Evict refresh-cache/lock entries older than the TTL. Caller must hold no lock."""
+        now = time.time()
+        with self._locks_guard:
+            stale = [
+                key
+                for key, outcome in self._refresh_cache.items()
+                if now - outcome.created_at > _REFRESH_CACHE_TTL_SECONDS
+            ]
+            for key in stale:
+                self._refresh_cache.pop(key, None)
+                self._session_locks.pop(key, None)
+
+    def check(self, request: RequestAdapter) -> SessionResult:
+        """Decide what to do with the incoming request's session cookie."""
+        cookie_value = request.get_cookie(self.cookie_name)
+        if not cookie_value:
+            return SessionResult(authenticated=False, reason="no_session")
+
+        try:
+            payload = decrypt_session(cookie_value, self._secret)
+        except InvalidSessionError:
+            return SessionResult(
+                authenticated=False, should_clear_cookie=True, reason="invalid_session"
+            )
+
+        expires_at = payload.get("expires_at", 0)
+        if expires_at - _EXPIRY_LEEWAY_SECONDS > time.time():
+            return SessionResult(authenticated=True, user=payload.get("user"))
+
+        refresh_token = payload.get("refresh_token")
+        if not refresh_token:
+            return SessionResult(
+                authenticated=False, should_clear_cookie=True, reason="invalid_session"
+            )
+
+        return self._refresh(refresh_token, payload)
+
+    def _refresh(self, refresh_token: str, old_payload: Dict[str, Any]) -> SessionResult:
+        self._sweep_expired_locked()
+        lock = self._lock_for(refresh_token)
+        with lock:
+            cached = self._refresh_cache.get(refresh_token)
+            if cached is not None:
+                return cached.session_result
+
+            try:
+                result = self._client.refresh_access_token(refresh_token)
+                new_payload = dict(old_payload)
+                new_payload["access_token"] = result["access_token"]
+                new_payload["refresh_token"] = result["refresh_token"]
+                new_payload["expires_at"] = time.time() + result.get("expires_in", 300)
+                new_cookie_value = encrypt_session(new_payload, self._secret)
+                session_result = SessionResult(
+                    authenticated=True,
+                    user=new_payload.get("user"),
+                    new_cookie_value=new_cookie_value,
+                )
+            except Exception:
+                session_result = SessionResult(
+                    authenticated=False,
+                    should_clear_cookie=True,
+                    reason="refresh_failed",
+                )
+
+            self._refresh_cache[refresh_token] = _RefreshOutcome(
+                session_result=session_result, created_at=time.time()
+            )
+            return session_result
+
+    def create_session_cookie(self, payload: Dict[str, Any]) -> str:
+        """Encrypt a fresh session payload (e.g. right after authenticate_with_code)."""
+        return encrypt_session(payload, self._secret)
+
+    def apply(self, result: SessionResult, response: ResponseAdapter) -> None:
+        """Apply a SessionResult's cookie side effects to an outgoing response."""
+        if result.new_cookie_value:
+            response.set_cookie(self.cookie_name, result.new_cookie_value)
+        elif result.should_clear_cookie:
+            response.delete_cookie(self.cookie_name)

--- a/scalekit/middleware/session_manager.py
+++ b/scalekit/middleware/session_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from dataclasses import dataclass
@@ -23,6 +24,8 @@ _EXPIRY_LEEWAY_SECONDS = 10
 # rotation grace window (~30s) so same-process concurrent callers racing within
 # that window all land on the cached result rather than each hitting the network.
 _REFRESH_CACHE_TTL_SECONDS = 60
+
+logger = logging.getLogger("scalekit.middleware.session_manager")
 
 
 @dataclass
@@ -134,10 +137,19 @@ class SessionRefreshManager:
 
             try:
                 result = self._client.refresh_access_token(refresh_token)
+                new_access_token = result["access_token"]
+                # Re-derive user/claims from the freshly-issued access token rather
+                # than carrying the old cached values forward. Access token claims
+                # (not id_token claims) are the source of truth here -- customers can
+                # configure custom access-token claims in the Scalekit dashboard, and
+                # unlike the id_token, the access token IS reissued on every refresh,
+                # so this keeps `user` genuinely current instead of stale-until-next-login.
+                claims = self._client.validate_access_token_and_get_claims(new_access_token)
                 new_payload = dict(old_payload)
-                new_payload["access_token"] = result["access_token"]
+                new_payload["access_token"] = new_access_token
                 new_payload["refresh_token"] = result["refresh_token"]
-                new_payload["expires_at"] = time.time() + result.get("expires_in", 300)
+                new_payload["user"] = claims
+                new_payload["expires_at"] = claims.get("exp", time.time() + 300)
                 new_cookie_value = encrypt_session(new_payload, self._secret)
                 session_result = SessionResult(
                     authenticated=True,
@@ -145,6 +157,10 @@ class SessionRefreshManager:
                     new_cookie_value=new_cookie_value,
                 )
             except Exception:
+                # Deliberately caught broadly -- any failure here means "treat as
+                # logged out," never a 500. But it must still be visible to
+                # whoever operates this app, so log it rather than swallow it.
+                logger.exception("token refresh failed; clearing session")
                 session_result = SessionResult(
                     authenticated=False,
                     should_clear_cookie=True,

--- a/scalekit/middleware/session_manager.py
+++ b/scalekit/middleware/session_manager.py
@@ -45,6 +45,15 @@ class _RefreshOutcome:
     created_at: float
 
 
+@dataclass
+class _LockEntry:
+    lock: threading.Lock
+    # Number of callers currently holding a reference to `lock` between
+    # `_lock_for()` returning and them finishing their `with lock:` block --
+    # see `_sweep_expired_locked` for why eviction must respect this.
+    ref_count: int = 0
+
+
 class SessionRefreshManager:
     """
     Framework-agnostic session state machine: decrypts the session cookie,
@@ -78,16 +87,23 @@ class SessionRefreshManager:
         self.cookie_name = cookie_name
 
         self._locks_guard = threading.Lock()
-        self._session_locks: Dict[str, threading.Lock] = {}
+        self._session_locks: Dict[str, _LockEntry] = {}
         self._refresh_cache: Dict[str, _RefreshOutcome] = {}
 
     def _lock_for(self, key: str) -> threading.Lock:
         with self._locks_guard:
-            lock = self._session_locks.get(key)
-            if lock is None:
-                lock = threading.Lock()
-                self._session_locks[key] = lock
-            return lock
+            entry = self._session_locks.get(key)
+            if entry is None:
+                entry = _LockEntry(lock=threading.Lock())
+                self._session_locks[key] = entry
+            entry.ref_count += 1
+            return entry.lock
+
+    def _release_lock_ref(self, key: str) -> None:
+        with self._locks_guard:
+            entry = self._session_locks.get(key)
+            if entry is not None:
+                entry.ref_count -= 1
 
     def _sweep_expired_locked(self) -> None:
         """Evict refresh-cache/lock entries older than the TTL. Caller must hold no lock."""
@@ -99,6 +115,16 @@ class SessionRefreshManager:
                 if now - outcome.created_at > _REFRESH_CACHE_TTL_SECONDS
             ]
             for key in stale:
+                entry = self._session_locks.get(key)
+                if entry is not None and entry.ref_count > 0:
+                    # A caller already holds a reference to this lock (got it from
+                    # _lock_for but hasn't reached `with lock:` yet) and may still
+                    # rely on reading this cached outcome once it does -- evicting
+                    # out from under it would force a redundant, possibly-failing
+                    # refresh call for an already-rotated token. Leave both entries
+                    # in place; a later sweep will clean them up once ref_count
+                    # drops back to 0.
+                    continue
                 self._refresh_cache.pop(key, None)
                 self._session_locks.pop(key, None)
 
@@ -130,51 +156,75 @@ class SessionRefreshManager:
     def _refresh(self, refresh_token: str, old_payload: Dict[str, Any]) -> SessionResult:
         self._sweep_expired_locked()
         lock = self._lock_for(refresh_token)
-        with lock:
-            cached = self._refresh_cache.get(refresh_token)
-            if cached is not None:
-                return cached.session_result
+        try:
+            with lock:
+                cached = self._refresh_cache.get(refresh_token)
+                if cached is not None:
+                    return cached.session_result
 
-            try:
-                result = self._client.refresh_access_token(refresh_token)
-                new_access_token = result["access_token"]
-                # Re-derive user/claims from the freshly-issued access token rather
-                # than carrying the old cached values forward. Access token claims
-                # (not id_token claims) are the source of truth here -- customers can
-                # configure custom access-token claims in the Scalekit dashboard, and
-                # unlike the id_token, the access token IS reissued on every refresh,
-                # so this keeps `user` genuinely current instead of stale-until-next-login.
-                claims = self._client.validate_access_token_and_get_claims(new_access_token)
-                new_payload = dict(old_payload)
-                new_payload["access_token"] = new_access_token
-                new_payload["refresh_token"] = result["refresh_token"]
-                new_payload["user"] = claims
-                new_payload["expires_at"] = claims.get("exp", time.time() + 300)
-                new_cookie_value = encrypt_session(new_payload, self._secret)
-                session_result = SessionResult(
-                    authenticated=True,
-                    user=new_payload.get("user"),
-                    new_cookie_value=new_cookie_value,
-                )
-            except Exception:
-                # Deliberately caught broadly -- any failure here means "treat as
-                # logged out," never a 500. But it must still be visible to
-                # whoever operates this app, so log it rather than swallow it.
-                logger.exception("token refresh failed; clearing session")
-                session_result = SessionResult(
-                    authenticated=False,
-                    should_clear_cookie=True,
-                    reason="refresh_failed",
-                )
+                try:
+                    result = self._client.refresh_access_token(refresh_token)
+                    new_access_token = result["access_token"]
+                    # Re-derive user/claims from the freshly-issued access token rather
+                    # than carrying the old cached values forward. Access token claims
+                    # (not id_token claims) are the source of truth here -- customers can
+                    # configure custom access-token claims in the Scalekit dashboard, and
+                    # unlike the id_token, the access token IS reissued on every refresh,
+                    # so this keeps `user` genuinely current instead of stale-until-next-login.
+                    claims = self._client.validate_access_token_and_get_claims(new_access_token)
+                    new_payload = dict(old_payload)
+                    new_payload["access_token"] = new_access_token
+                    new_payload["refresh_token"] = result["refresh_token"]
+                    new_payload["user"] = claims
+                    new_payload["expires_at"] = claims.get("exp", time.time() + 300)
+                    new_cookie_value = encrypt_session(new_payload, self._secret)
+                    session_result = SessionResult(
+                        authenticated=True,
+                        user=new_payload.get("user"),
+                        new_cookie_value=new_cookie_value,
+                    )
+                    self._refresh_cache[refresh_token] = _RefreshOutcome(
+                        session_result=session_result, created_at=time.time()
+                    )
+                except Exception:
+                    # Deliberately caught broadly -- any failure here means "treat as
+                    # logged out," never a 500. But it must still be visible to
+                    # whoever operates this app, so log it rather than swallow it.
+                    logger.exception("token refresh failed; clearing session")
+                    session_result = SessionResult(
+                        authenticated=False,
+                        should_clear_cookie=True,
+                        reason="refresh_failed",
+                    )
+                    # Deliberately NOT cached: a failure here may be a transient
+                    # network error (timeout, 503), not proof the refresh_token is
+                    # actually dead. Caching it for the full TTL would pin every
+                    # concurrent caller of this session to "logged out" for up to
+                    # 60s with no chance to retry. Concurrent callers already in
+                    # this `with lock:` block are still coalesced onto this single
+                    # attempt; only a *later*, non-overlapping call gets to retry.
 
-            self._refresh_cache[refresh_token] = _RefreshOutcome(
-                session_result=session_result, created_at=time.time()
-            )
-            return session_result
+                return session_result
+        finally:
+            self._release_lock_ref(refresh_token)
 
     def create_session_cookie(self, payload: Dict[str, Any]) -> str:
         """Encrypt a fresh session payload (e.g. right after authenticate_with_code)."""
         return encrypt_session(payload, self._secret)
+
+    def read_session(self, cookie_value: str) -> Optional[Dict[str, Any]]:
+        """
+        Decrypt a session cookie for read-only inspection (e.g. logout reading
+        `id_token` for the logout hint), without going through the full
+        expiry/refresh state machine in `check()`. Returns None instead of
+        raising if the cookie is missing, malformed, or tampered with --
+        framework adapters should never need to import InvalidSessionError
+        or reach into this manager's internals to get at the payload.
+        """
+        try:
+            return decrypt_session(cookie_value, self._secret)
+        except InvalidSessionError:
+            return None
 
     def apply(self, result: SessionResult, response: ResponseAdapter) -> None:
         """Apply a SessionResult's cookie side effects to an outgoing response."""

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         # install_requires so installing the core SDK never pulls in a web
         # framework the customer isn't using.
         "flask": ["flask>=2.0"],
+        "fastapi": ["fastapi>=0.100"],
     },
     url="https://github.com/scalekit-inc/scalekit-sdk-python",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         # framework the customer isn't using.
         "flask": ["flask>=2.0"],
         "fastapi": ["fastapi>=0.100"],
+        "django": ["django>=4.2"],
     },
     url="https://github.com/scalekit-inc/scalekit-sdk-python",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,12 @@ setup(
         "pydantic>=2.13.4",
         "mcp>=1.27.2",
     ],
+    extras_require={
+        # Framework-specific extras for scalekit.frameworks.* -- kept out of
+        # install_requires so installing the core SDK never pulls in a web
+        # framework the customer isn't using.
+        "flask": ["flask>=2.0"],
+    },
     url="https://github.com/scalekit-inc/scalekit-sdk-python",
     license="MIT",
     author="Team Scalekit",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "requests>=2.34.0",
         "PyJWT>=2.13.0",
         "cffi>=1.15.1",
-        "cryptography>=46.0.6,<49",
+        "cryptography>=50.0.0",
         "setuptools>=82.0.1,<83.0",
         "grpcio-status>=1.81.0,<2.0",
         "protoc-gen-openapiv2>=0.0.1",

--- a/tests/test_middleware_csrf_state.py
+++ b/tests/test_middleware_csrf_state.py
@@ -1,0 +1,47 @@
+from scalekit.middleware.csrf_state import (
+    generate_state,
+    sanitize_return_to,
+    verify_state,
+)
+
+
+class TestGenerateStateVerifyState:
+    def test_verifies_a_matching_state(self):
+        state = generate_state()
+        assert verify_state(state, state) is True
+
+    def test_rejects_a_mismatched_state(self):
+        assert verify_state(generate_state(), generate_state()) is False
+
+    def test_rejects_when_either_side_is_missing(self):
+        state = generate_state()
+        assert verify_state(None, state) is False
+        assert verify_state(state, None) is False
+        assert verify_state(None, None) is False
+
+
+class TestSanitizeReturnTo:
+    def test_accepts_a_same_origin_relative_path(self):
+        assert sanitize_return_to("/account") == "/account"
+        assert sanitize_return_to("/account?tab=billing") == "/account?tab=billing"
+
+    def test_rejects_an_absolute_url(self):
+        assert sanitize_return_to("https://evil.com") is None
+
+    def test_rejects_a_protocol_relative_url(self):
+        assert sanitize_return_to("//evil.com") is None
+
+    def test_rejects_embedded_tab_cr_lf_bypass(self):
+        # Browsers strip these during URL parsing (WHATWG URL spec), so
+        # "/\t/evil.com" would otherwise normalize to the protocol-relative
+        # "//evil.com" after a naive startswith('/') check passed it through.
+        assert sanitize_return_to("/\t/evil.com") is None
+        assert sanitize_return_to("/\r/evil.com") is None
+        assert sanitize_return_to("/\n/evil.com") is None
+
+    def test_rejects_a_value_not_starting_with_a_slash(self):
+        assert sanitize_return_to("account") is None
+
+    def test_returns_none_for_missing_input(self):
+        assert sanitize_return_to(None) is None
+        assert sanitize_return_to("") is None

--- a/tests/test_middleware_django.py
+++ b/tests/test_middleware_django.py
@@ -62,7 +62,7 @@ class TestScalekitAuthDjango(unittest.TestCase):
         self.client_mock.get_authorization_url.return_value = (
             "https://auth.example.com/oauth/authorize?client_id=x"
         )
-        resp = Client().get("/login/")
+        resp = Client().get("/login")
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
@@ -80,7 +80,7 @@ class TestScalekitAuthDjango(unittest.TestCase):
             "exp": time.time() + 300,
         }
 
-        resp = Client().get("/callback/?code=abc123")
+        resp = Client().get("/callback?code=abc123")
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
@@ -165,7 +165,7 @@ class TestScalekitAuthDjango(unittest.TestCase):
         self.assertEqual(resp.headers["Location"], "/login")
 
     def test_logout_without_any_cookie_falls_back_to_local_redirect(self):
-        resp = Client().get("/logout/")
+        resp = Client().get("/logout")
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
@@ -187,7 +187,7 @@ class TestScalekitAuthDjango(unittest.TestCase):
         tc = Client()
         tc.cookies["sk_session"] = cookie_value
 
-        resp = tc.get("/logout/")
+        resp = tc.get("/logout")
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "https://auth.example.com/oidc/logout?id_token_hint=abc")
@@ -211,7 +211,7 @@ class TestScalekitAuthDjango(unittest.TestCase):
         tc = Client()
         tc.cookies["sk_session"] = cookie_value
 
-        resp = tc.get("/logout/")
+        resp = tc.get("/logout")
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")

--- a/tests/test_middleware_django.py
+++ b/tests/test_middleware_django.py
@@ -74,6 +74,36 @@ class TestScalekitAuthDjango(unittest.TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
 
+    def test_login_with_idp_initiated_login_uses_claims_for_authorization_url(self):
+        self.client_mock.get_idp_initiated_login_claims.return_value = {
+            "connection_id": "conn_123",
+            "organization_id": "org_456",
+            "login_hint": "user@example.com",
+        }
+        self.client_mock.get_authorization_url.return_value = (
+            "https://auth.example.com/oauth/authorize?client_id=x"
+        )
+
+        resp = Client().get("/login?idp_initiated_login=some.jwt.token")
+
+        self.assertEqual(resp.status_code, 302)
+        self.client_mock.get_idp_initiated_login_claims.assert_called_once_with("some.jwt.token")
+        call_options = self.client_mock.get_authorization_url.call_args[0][1]
+        self.assertEqual(call_options.connection_id, "conn_123")
+        self.assertEqual(call_options.organization_id, "org_456")
+        self.assertEqual(call_options.login_hint, "user@example.com")
+
+    def test_login_with_invalid_idp_initiated_login_falls_back_to_normal_login(self):
+        self.client_mock.get_idp_initiated_login_claims.side_effect = Exception("invalid token")
+        self.client_mock.get_authorization_url.return_value = (
+            "https://auth.example.com/oauth/authorize?client_id=x"
+        )
+
+        resp = Client().get("/login?idp_initiated_login=garbage")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
+
     def test_callback_sets_encrypted_cookie_and_redirects(self):
         self.client_mock.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
         self.client_mock.authenticate_with_code.return_value = {

--- a/tests/test_middleware_django.py
+++ b/tests/test_middleware_django.py
@@ -22,7 +22,7 @@ from django.http import HttpResponse
 from django.test import Client
 from django.urls import include, path
 
-from scalekit.frameworks.django import get_config, login_required
+from scalekit.frameworks.django import get_config, get_session, login_required
 from scalekit.middleware.session_crypto import decrypt_session
 
 
@@ -32,8 +32,16 @@ def account_view(request):
 
 account_view = login_required(account_view)
 
+
+def whoami_view(request):
+    import json
+
+    return HttpResponse(json.dumps({"session": get_session(request)}), content_type="application/json")
+
+
 urlpatterns = [
     path("account", account_view),
+    path("whoami", whoami_view),
     path("", include("scalekit.frameworks.django")),
 ]
 
@@ -169,7 +177,7 @@ class TestScalekitAuthDjango(unittest.TestCase):
         resp = Client().get("/account")
 
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.headers["Location"], "/login")
+        self.assertEqual(resp.headers["Location"], "/login?returnTo=%2Faccount")
         self.assertNotEqual(resp.headers.get("Content-Type"), "application/json")
 
     def test_protected_route_with_valid_session_succeeds(self):
@@ -235,7 +243,7 @@ class TestScalekitAuthDjango(unittest.TestCase):
         resp = tc.get("/account")
 
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.headers["Location"], "/login")
+        self.assertEqual(resp.headers["Location"], "/login?returnTo=%2Faccount")
 
     def test_logout_without_any_cookie_falls_back_to_local_redirect(self):
         resp = Client().get("/logout")
@@ -307,6 +315,113 @@ class TestScalekitAuthDjangoConstruction(unittest.TestCase):
         django_settings.SCALEKIT_CLIENT = MagicMock()
         with self.assertRaises(ValueError):
             get_config()
+
+
+class TestScalekitAuthDjangoReturnTo(unittest.TestCase):
+    def setUp(self):
+        self.config = _reconfigure(secret="django-test-cookie-secret")
+        self.client_mock = self.config.client
+
+    def tearDown(self):
+        get_config.cache_clear()
+
+    def test_login_redirect_round_trips_back_to_originally_requested_page(self):
+        self.client_mock.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+        self.client_mock.authenticate_with_code.return_value = {
+            "user": {"email": "test.user@example.com"},
+            "access_token": "at_1",
+            "refresh_token": "rt_1",
+            "id_token": "idt_1",
+            "expires_in": 300,
+        }
+        self.client_mock.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+
+        tc = Client()
+        gate_resp = tc.get("/account")
+        self.assertEqual(gate_resp.headers["Location"], "/login?returnTo=%2Faccount")
+
+        tc.get(gate_resp.headers["Location"])
+        state = tc.cookies["sk_oauth_state"].value
+        self.assertEqual(tc.cookies["sk_return_to"].value, "/account")
+
+        callback_resp = tc.get(f"/callback?code=abc123&state={state}")
+
+        self.assertEqual(callback_resp.status_code, 302)
+        self.assertEqual(callback_resp.headers["Location"], "/account")
+
+    def test_login_rejects_absolute_url_return_to_falls_back_to_default(self):
+        self.client_mock.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+        self.client_mock.authenticate_with_code.return_value = {
+            "user": {"email": "test.user@example.com"},
+            "access_token": "at_1",
+            "expires_in": 300,
+        }
+        self.client_mock.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+
+        tc = Client()
+        tc.get("/login?returnTo=https://evil.com")
+        self.assertNotIn("sk_return_to", tc.cookies)
+        state = tc.cookies["sk_oauth_state"].value
+        resp = tc.get(f"/callback?code=abc123&state={state}")
+
+        self.assertEqual(resp.headers["Location"], "/")
+
+
+class TestScalekitAuthDjangoGetSession(unittest.TestCase):
+    def setUp(self):
+        self.config = _reconfigure(secret="django-test-cookie-secret")
+
+    def tearDown(self):
+        get_config.cache_clear()
+
+    def test_get_session_returns_curated_user_and_expiry_for_valid_cookie(self):
+        expires_at = time.time() + 3600
+        cookie_value = self.config.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "id_token": "idt_1",
+                "expires_at": expires_at,
+            }
+        )
+        tc = Client()
+        tc.cookies["sk_session"] = cookie_value
+
+        resp = tc.get("/whoami")
+
+        self.assertEqual(
+            resp.json()["session"],
+            {"user": {"email": "test.user@example.com"}, "expires_at": expires_at},
+        )
+
+    def test_get_session_returns_none_for_missing_cookie(self):
+        resp = Client().get("/whoami")
+
+        self.assertIsNone(resp.json()["session"])
+
+
+class TestScalekitAuthDjangoCookieSecure(unittest.TestCase):
+    def tearDown(self):
+        get_config.cache_clear()
+
+    def test_cookie_secure_false_omits_secure_attribute_for_local_http_dev(self):
+        get_config.cache_clear()
+        django_settings.SCALEKIT_COOKIE_SECURE = False
+        self.addCleanup(setattr, django_settings, "SCALEKIT_COOKIE_SECURE", True)
+        config = get_config()
+        config.client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+
+        resp = Client().get("/login")
+
+        set_cookie_header = str(resp.cookies.get("sk_oauth_state", ""))
+        self.assertNotIn("Secure", set_cookie_header)
 
 
 if __name__ == "__main__":

--- a/tests/test_middleware_django.py
+++ b/tests/test_middleware_django.py
@@ -49,6 +49,13 @@ def _reconfigure(secret=None, full_logout=None):
     return get_config()
 
 
+def _login_and_get_state(tc):
+    """Drive /login through the test client to obtain a valid state cookie,
+    exactly as a real browser would before hitting /callback."""
+    tc.get("/login")
+    return tc.cookies["sk_oauth_state"].value
+
+
 class TestScalekitAuthDjango(unittest.TestCase):
     def setUp(self):
         django_settings.SCALEKIT_FULL_LOGOUT = True
@@ -68,6 +75,7 @@ class TestScalekitAuthDjango(unittest.TestCase):
         self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
 
     def test_callback_sets_encrypted_cookie_and_redirects(self):
+        self.client_mock.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
         self.client_mock.authenticate_with_code.return_value = {
             "user": {"email": "test.user@example.com"},
             "access_token": "at_1",
@@ -80,7 +88,9 @@ class TestScalekitAuthDjango(unittest.TestCase):
             "exp": time.time() + 300,
         }
 
-        resp = Client().get("/callback?code=abc123")
+        tc = Client()
+        state = _login_and_get_state(tc)
+        resp = tc.get(f"/callback?code=abc123&state={state}")
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
@@ -88,6 +98,39 @@ class TestScalekitAuthDjango(unittest.TestCase):
         self.assertIn("sk_session=", set_cookie_header)
         self.assertIn("HttpOnly", set_cookie_header)
         self.assertIn("Secure", set_cookie_header)
+
+    def test_callback_with_provider_error_redirects_to_login_not_500(self):
+        resp = Client().get("/callback?error=access_denied")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        self.client_mock.authenticate_with_code.assert_not_called()
+
+    def test_callback_with_missing_code_redirects_to_login(self):
+        resp = Client().get("/callback")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        self.client_mock.authenticate_with_code.assert_not_called()
+
+    def test_callback_with_missing_state_redirects_to_login(self):
+        # No /login call at all -- no state cookie exists, simulating a
+        # forged callback URL sent directly to a victim.
+        resp = Client().get("/callback?code=abc123&state=whatever")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        self.client_mock.authenticate_with_code.assert_not_called()
+
+    def test_callback_with_mismatched_state_redirects_to_login(self):
+        self.client_mock.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+        tc = Client()
+        _login_and_get_state(tc)
+        resp = tc.get("/callback?code=abc123&state=attacker-supplied")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        self.client_mock.authenticate_with_code.assert_not_called()
 
     def test_protected_route_without_cookie_redirects_to_login_not_json_401(self):
         # Same property tested for Flask/FastAPI: "no valid session" must be a
@@ -224,11 +267,16 @@ class TestScalekitAuthDjangoConstruction(unittest.TestCase):
 
     def test_missing_cookie_secret_raises_immediately(self):
         get_config.cache_clear()
+        # Restore via addCleanup, not a bare post-assertion line -- if the
+        # assertion below ever failed, the setting would stay "" for every
+        # later test in the run for an unrelated reason.
+        self.addCleanup(
+            setattr, django_settings, "SCALEKIT_COOKIE_ENCRYPTION_SECRET", "django-test-cookie-secret"
+        )
         django_settings.SCALEKIT_COOKIE_ENCRYPTION_SECRET = ""
         django_settings.SCALEKIT_CLIENT = MagicMock()
         with self.assertRaises(ValueError):
             get_config()
-        django_settings.SCALEKIT_COOKIE_ENCRYPTION_SECRET = "django-test-cookie-secret"
 
 
 if __name__ == "__main__":

--- a/tests/test_middleware_django.py
+++ b/tests/test_middleware_django.py
@@ -1,0 +1,235 @@
+import time
+import unittest
+from unittest.mock import MagicMock
+
+import django
+from django.conf import settings as django_settings
+
+if not django_settings.configured:
+    django_settings.configure(
+        DEBUG=True,
+        SECRET_KEY="django-test-secret-key",
+        ALLOWED_HOSTS=["testserver"],
+        ROOT_URLCONF="tests.test_middleware_django",  # this module doubles as urlconf below
+        MIDDLEWARE=["scalekit.frameworks.django.ScalekitAuthMiddleware"],
+        SCALEKIT_REDIRECT_URI="https://app.example.com/callback",
+        SCALEKIT_COOKIE_ENCRYPTION_SECRET="django-test-cookie-secret",
+        SCALEKIT_CLIENT=MagicMock(),
+    )
+    django.setup()
+
+from django.http import HttpResponse
+from django.test import Client
+from django.urls import include, path
+
+from scalekit.frameworks.django import get_config, login_required
+from scalekit.middleware.session_crypto import decrypt_session
+
+
+def account_view(request):
+    return HttpResponse(f"hello {request.scalekit_user['email']}")
+
+
+account_view = login_required(account_view)
+
+urlpatterns = [
+    path("account", account_view),
+    path("", include("scalekit.frameworks.django")),
+]
+
+
+def _reconfigure(secret=None, full_logout=None):
+    """Force ScalekitAuthConfig to rebuild with fresh settings for this test."""
+    get_config.cache_clear()
+    if secret is not None:
+        django_settings.SCALEKIT_COOKIE_ENCRYPTION_SECRET = secret
+    if full_logout is not None:
+        django_settings.SCALEKIT_FULL_LOGOUT = full_logout
+    django_settings.SCALEKIT_CLIENT = MagicMock()
+    return get_config()
+
+
+class TestScalekitAuthDjango(unittest.TestCase):
+    def setUp(self):
+        django_settings.SCALEKIT_FULL_LOGOUT = True
+        self.config = _reconfigure(secret="django-test-cookie-secret")
+        self.client_mock = self.config.client
+
+    def tearDown(self):
+        get_config.cache_clear()
+
+    def test_login_redirects_to_authorization_url(self):
+        self.client_mock.get_authorization_url.return_value = (
+            "https://auth.example.com/oauth/authorize?client_id=x"
+        )
+        resp = Client().get("/login/")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
+
+    def test_callback_sets_encrypted_cookie_and_redirects(self):
+        self.client_mock.authenticate_with_code.return_value = {
+            "user": {"email": "test.user@example.com"},
+            "access_token": "at_1",
+            "refresh_token": "rt_1",
+            "id_token": "idt_1",
+            "expires_in": 300,
+        }
+        self.client_mock.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+
+        resp = Client().get("/callback/?code=abc123")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        set_cookie_header = str(resp.cookies.get("sk_session", ""))
+        self.assertIn("sk_session=", set_cookie_header)
+        self.assertIn("HttpOnly", set_cookie_header)
+        self.assertIn("Secure", set_cookie_header)
+
+    def test_protected_route_without_cookie_redirects_to_login_not_json_401(self):
+        # Same property tested for Flask/FastAPI: "no valid session" must be a
+        # real redirect a browser follows, not a JSON 401 a background fetch
+        # would silently swallow.
+        resp = Client().get("/account")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        self.assertNotEqual(resp.headers.get("Content-Type"), "application/json")
+
+    def test_protected_route_with_valid_session_succeeds(self):
+        cookie_value = self.config.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+        tc = Client()
+        tc.cookies["sk_session"] = cookie_value
+
+        resp = tc.get("/account")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"test.user@example.com", resp.content)
+        self.client_mock.refresh_access_token.assert_not_called()
+
+    def test_protected_route_with_expired_session_refreshes_transparently(self):
+        self.client_mock.refresh_access_token.return_value = {
+            "access_token": "at_new",
+            "refresh_token": "rt_new",
+        }
+        self.client_mock.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+        cookie_value = self.config.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_old",
+                "refresh_token": "rt_old",
+                "expires_at": time.time() - 10,
+            }
+        )
+        tc = Client()
+        tc.cookies["sk_session"] = cookie_value
+
+        resp = tc.get("/account")
+
+        self.assertEqual(resp.status_code, 200)
+        self.client_mock.refresh_access_token.assert_called_once_with("rt_old")
+
+        new_cookie_value = resp.cookies["sk_session"].value
+        new_payload = decrypt_session(new_cookie_value, "django-test-cookie-secret")
+        self.assertEqual(new_payload["access_token"], "at_new")
+
+    def test_protected_route_with_failed_refresh_clears_cookie_and_redirects(self):
+        self.client_mock.refresh_access_token.side_effect = Exception("invalid_grant")
+        cookie_value = self.config.manager.create_session_cookie(
+            {
+                "user": {"email": "user@example.com"},
+                "access_token": "at_old",
+                "refresh_token": "rt_old",
+                "expires_at": time.time() - 10,
+            }
+        )
+        tc = Client()
+        tc.cookies["sk_session"] = cookie_value
+
+        resp = tc.get("/account")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+
+    def test_logout_without_any_cookie_falls_back_to_local_redirect(self):
+        resp = Client().get("/logout/")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        self.client_mock.get_logout_url.assert_not_called()
+
+    def test_logout_with_valid_session_does_full_logout_via_id_token_hint(self):
+        self.client_mock.get_logout_url.return_value = (
+            "https://auth.example.com/oidc/logout?id_token_hint=abc"
+        )
+        cookie_value = self.config.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "id_token": "idt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+        tc = Client()
+        tc.cookies["sk_session"] = cookie_value
+
+        resp = tc.get("/logout/")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "https://auth.example.com/oidc/logout?id_token_hint=abc")
+
+        call_options = self.client_mock.get_logout_url.call_args[0][0]
+        self.assertEqual(call_options.id_token_hint, "idt_1")
+        self.assertTrue(call_options.post_logout_redirect_uri.startswith("http://"))
+
+    def test_full_logout_disabled_does_local_only_logout(self):
+        self.config = _reconfigure(secret="django-test-cookie-secret", full_logout=False)
+        self.client_mock = self.config.client
+        cookie_value = self.config.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "id_token": "idt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+        tc = Client()
+        tc.cookies["sk_session"] = cookie_value
+
+        resp = tc.get("/logout/")
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        self.client_mock.get_logout_url.assert_not_called()
+
+
+class TestScalekitAuthDjangoConstruction(unittest.TestCase):
+    def tearDown(self):
+        get_config.cache_clear()
+
+    def test_missing_cookie_secret_raises_immediately(self):
+        get_config.cache_clear()
+        django_settings.SCALEKIT_COOKIE_ENCRYPTION_SECRET = ""
+        django_settings.SCALEKIT_CLIENT = MagicMock()
+        with self.assertRaises(ValueError):
+            get_config()
+        django_settings.SCALEKIT_COOKIE_ENCRYPTION_SECRET = "django-test-cookie-secret"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_middleware_fastapi.py
+++ b/tests/test_middleware_fastapi.py
@@ -2,7 +2,7 @@ import time
 import unittest
 from unittest.mock import MagicMock
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.testclient import TestClient
 
 from scalekit.frameworks.fastapi import ScalekitAuth
@@ -164,7 +164,7 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
             resp = tc.get("/account", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.headers["Location"], "/login")
+        self.assertEqual(resp.headers["Location"], "/login?returnTo=%2Faccount")
         self.assertNotEqual(resp.headers.get("content-type"), "application/json")
 
     def test_protected_route_with_valid_session_succeeds(self):
@@ -235,7 +235,7 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
             resp = tc.get("/account", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.headers["Location"], "/login")
+        self.assertEqual(resp.headers["Location"], "/login?returnTo=%2Faccount")
 
     def test_logout_with_invalid_cookie_falls_back_to_local_redirect(self):
         app, auth, client = _build_app()
@@ -321,6 +321,113 @@ class TestScalekitAuthFastAPIConstruction(unittest.TestCase):
                 redirect_uri="https://app.example.com/callback",
                 cookie_encryption_secret="",
             )
+
+    def test_missing_redirect_uri_raises_immediately(self):
+        with self.assertRaises(ValueError):
+            ScalekitAuth(client=MagicMock(), cookie_encryption_secret="some-secret")
+
+
+class TestScalekitAuthFastAPIReturnTo(unittest.TestCase):
+    def test_login_redirect_round_trips_back_to_originally_requested_page(self):
+        app, auth, client = _build_app(secret="return-to-secret")
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+        client.authenticate_with_code.return_value = {
+            "user": {"email": "test.user@example.com"},
+            "access_token": "at_1",
+            "refresh_token": "rt_1",
+            "id_token": "idt_1",
+            "expires_in": 300,
+        }
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+
+        with _https_client(app) as tc:
+            gate_resp = tc.get("/account", follow_redirects=False)
+            self.assertEqual(gate_resp.headers["Location"], "/login?returnTo=%2Faccount")
+
+            tc.get(gate_resp.headers["Location"], follow_redirects=False)
+            state = tc.cookies.get("sk_oauth_state")
+            self.assertEqual(tc.cookies.get("sk_return_to").strip(chr(34)), "/account")
+
+            callback_resp = tc.get(f"/callback?code=abc123&state={state}", follow_redirects=False)
+
+        self.assertEqual(callback_resp.status_code, 302)
+        self.assertEqual(callback_resp.headers["Location"], "/account")
+
+    def test_login_rejects_absolute_url_return_to_falls_back_to_default(self):
+        app, auth, client = _build_app(secret="open-redirect-secret")
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+        client.authenticate_with_code.return_value = {
+            "user": {"email": "test.user@example.com"},
+            "access_token": "at_1",
+            "expires_in": 300,
+        }
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+
+        with _https_client(app) as tc:
+            tc.get("/login?returnTo=https://evil.com", follow_redirects=False)
+            self.assertIsNone(tc.cookies.get("sk_return_to"))
+            state = tc.cookies.get("sk_oauth_state")
+            resp = tc.get(f"/callback?code=abc123&state={state}", follow_redirects=False)
+
+        self.assertEqual(resp.headers["Location"], "/")
+
+
+class TestScalekitAuthFastAPIGetSession(unittest.TestCase):
+    def test_get_session_returns_curated_user_and_expiry_for_valid_cookie(self):
+        app, auth, client = _build_app(secret="get-session-secret")
+        expires_at = time.time() + 3600
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "id_token": "idt_1",
+                "expires_at": expires_at,
+            }
+        )
+
+        @app.get("/whoami")
+        async def whoami(request: Request):
+            return {"session": auth.get_session(request)}
+
+        with _https_client(app) as tc:
+            tc.cookies.set("sk_session", cookie_value)
+            resp = tc.get("/whoami")
+
+        self.assertEqual(
+            resp.json()["session"],
+            {"user": {"email": "test.user@example.com"}, "expires_at": expires_at},
+        )
+
+    def test_get_session_returns_none_for_missing_cookie(self):
+        app, auth, client = _build_app(secret="get-session-secret-2")
+
+        @app.get("/whoami")
+        async def whoami(request: Request):
+            return {"session": auth.get_session(request)}
+
+        with _https_client(app) as tc:
+            resp = tc.get("/whoami")
+
+        self.assertIsNone(resp.json()["session"])
+
+
+class TestScalekitAuthFastAPICookieSecure(unittest.TestCase):
+    def test_cookie_secure_false_omits_secure_attribute_for_local_http_dev(self):
+        app, auth, client = _build_app(secret="cookie-secure-secret", cookie_secure=False)
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+
+        with _https_client(app) as tc:
+            resp = tc.get("/login", follow_redirects=False)
+
+        set_cookie_header = resp.headers.get("set-cookie", "")
+        self.assertNotIn("Secure", set_cookie_header)
 
 
 if __name__ == "__main__":

--- a/tests/test_middleware_fastapi.py
+++ b/tests/test_middleware_fastapi.py
@@ -53,6 +53,36 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
 
+    def test_login_with_idp_initiated_login_uses_claims_for_authorization_url(self):
+        app, auth, client = _build_app()
+        client.get_idp_initiated_login_claims.return_value = {
+            "connection_id": "conn_123",
+            "organization_id": "org_456",
+            "login_hint": "user@example.com",
+        }
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize?client_id=x"
+
+        with _https_client(app) as tc:
+            resp = tc.get("/login?idp_initiated_login=some.jwt.token", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        client.get_idp_initiated_login_claims.assert_called_once_with("some.jwt.token")
+        call_options = client.get_authorization_url.call_args[0][1]
+        self.assertEqual(call_options.connection_id, "conn_123")
+        self.assertEqual(call_options.organization_id, "org_456")
+        self.assertEqual(call_options.login_hint, "user@example.com")
+
+    def test_login_with_invalid_idp_initiated_login_falls_back_to_normal_login(self):
+        app, auth, client = _build_app()
+        client.get_idp_initiated_login_claims.side_effect = Exception("invalid token")
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize?client_id=x"
+
+        with _https_client(app) as tc:
+            resp = tc.get("/login?idp_initiated_login=garbage", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
+
     def test_callback_sets_encrypted_cookie_and_redirects(self):
         app, auth, client = _build_app(secret="callback-secret")
         client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"

--- a/tests/test_middleware_fastapi.py
+++ b/tests/test_middleware_fastapi.py
@@ -27,12 +27,27 @@ def _build_app(client=None, secret="fastapi-test-secret", **auth_kwargs):
     return app, auth, mock_client
 
 
+def _https_client(app):
+    # httpx's cookie jar (unlike Flask's test client) correctly refuses to
+    # resend a Secure cookie over a plain http:// request -- our state/session
+    # cookies are Secure by default, matching real deployment behind TLS, so
+    # the test client must actually be https to exercise that round trip.
+    return TestClient(app, base_url="https://testserver")
+
+
+def _login_and_get_state(tc):
+    """Drive /login through the test client to obtain a valid state cookie,
+    exactly as a real browser would before hitting /callback."""
+    tc.get("/login", follow_redirects=False)
+    return tc.cookies.get("sk_oauth_state")
+
+
 class TestScalekitAuthFastAPI(unittest.TestCase):
     def test_login_redirects_to_authorization_url(self):
         app, auth, client = _build_app()
         client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize?client_id=x"
 
-        with TestClient(app) as tc:
+        with _https_client(app) as tc:
             resp = tc.get("/login", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
@@ -40,6 +55,7 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
 
     def test_callback_sets_encrypted_cookie_and_redirects(self):
         app, auth, client = _build_app(secret="callback-secret")
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
         client.authenticate_with_code.return_value = {
             "user": {"email": "test.user@example.com"},
             "access_token": "at_1",
@@ -52,8 +68,9 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
             "exp": time.time() + 300,
         }
 
-        with TestClient(app) as tc:
-            resp = tc.get("/callback?code=abc123", follow_redirects=False)
+        with _https_client(app) as tc:
+            state = _login_and_get_state(tc)
+            resp = tc.get(f"/callback?code=abc123&state={state}", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
@@ -62,6 +79,50 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
         self.assertIn("HttpOnly", set_cookie_header)
         self.assertIn("Secure", set_cookie_header)
 
+    def test_callback_with_provider_error_redirects_to_login_not_500(self):
+        app, auth, client = _build_app()
+
+        with _https_client(app) as tc:
+            resp = tc.get("/callback?error=access_denied", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        client.authenticate_with_code.assert_not_called()
+
+    def test_callback_with_missing_code_redirects_to_login(self):
+        app, auth, client = _build_app()
+
+        with _https_client(app) as tc:
+            resp = tc.get("/callback", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        client.authenticate_with_code.assert_not_called()
+
+    def test_callback_with_missing_state_redirects_to_login(self):
+        # No /login call at all -- no state cookie exists, simulating a
+        # forged callback URL sent directly to a victim.
+        app, auth, client = _build_app()
+
+        with _https_client(app) as tc:
+            resp = tc.get("/callback?code=abc123&state=whatever", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        client.authenticate_with_code.assert_not_called()
+
+    def test_callback_with_mismatched_state_redirects_to_login(self):
+        app, auth, client = _build_app()
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+
+        with _https_client(app) as tc:
+            _login_and_get_state(tc)
+            resp = tc.get("/callback?code=abc123&state=attacker-supplied", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        client.authenticate_with_code.assert_not_called()
+
     def test_protected_route_without_cookie_redirects_to_login_not_json_401(self):
         # Same property tested for Flask: "no valid session" must be a real
         # redirect a browser follows, not a JSON 401 a background fetch would
@@ -69,7 +130,7 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
         # forced-logout incident this feature was motivated by.
         app, auth, client = _build_app()
 
-        with TestClient(app) as tc:
+        with _https_client(app) as tc:
             resp = tc.get("/account", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
@@ -87,7 +148,7 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
             }
         )
 
-        with TestClient(app) as tc:
+        with _https_client(app) as tc:
             tc.cookies.set("sk_session", cookie_value)
             resp = tc.get("/account")
 
@@ -114,7 +175,7 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
             }
         )
 
-        with TestClient(app) as tc:
+        with _https_client(app) as tc:
             tc.cookies.set("sk_session", cookie_value)
             resp = tc.get("/account")
 
@@ -139,7 +200,7 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
             }
         )
 
-        with TestClient(app) as tc:
+        with _https_client(app) as tc:
             tc.cookies.set("sk_session", cookie_value)
             resp = tc.get("/account", follow_redirects=False)
 
@@ -149,18 +210,21 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
     def test_logout_with_invalid_cookie_falls_back_to_local_redirect(self):
         app, auth, client = _build_app()
 
-        with TestClient(app) as tc:
+        with _https_client(app) as tc:
             tc.cookies.set("sk_session", "some-value")
             resp = tc.get("/logout", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
+        set_cookie_header = resp.headers.get("set-cookie", "")
+        self.assertIn('sk_session=""', set_cookie_header)
+        self.assertIn("Max-Age=0", set_cookie_header)
         client.get_logout_url.assert_not_called()
 
     def test_logout_without_any_cookie_falls_back_to_local_redirect(self):
         app, auth, client = _build_app()
 
-        with TestClient(app) as tc:
+        with _https_client(app) as tc:
             resp = tc.get("/logout", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
@@ -180,18 +244,20 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
             }
         )
 
-        with TestClient(app) as tc:
+        with _https_client(app) as tc:
             tc.cookies.set("sk_session", cookie_value)
             resp = tc.get("/logout", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "https://auth.example.com/oidc/logout?id_token_hint=abc")
         set_cookie_header = resp.headers.get("set-cookie", "")
-        self.assertIn("sk_session=", set_cookie_header)
+        # local cookie is actually cleared too, not just present/reissued
+        self.assertIn('sk_session=""', set_cookie_header)
+        self.assertIn("Max-Age=0", set_cookie_header)
 
         call_options = client.get_logout_url.call_args[0][0]
         self.assertEqual(call_options.id_token_hint, "idt_1")
-        self.assertTrue(call_options.post_logout_redirect_uri.startswith("http://"))
+        self.assertTrue(call_options.post_logout_redirect_uri.startswith("https://"))
 
     def test_full_logout_disabled_does_local_only_logout(self):
         app, auth, client = _build_app(secret="local-only-secret", full_logout=False)
@@ -205,13 +271,16 @@ class TestScalekitAuthFastAPI(unittest.TestCase):
             }
         )
 
-        with TestClient(app) as tc:
+        with _https_client(app) as tc:
             tc.cookies.set("sk_session", cookie_value)
             resp = tc.get("/logout", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
         client.get_logout_url.assert_not_called()
+        set_cookie_header = resp.headers.get("set-cookie", "")
+        self.assertIn('sk_session=""', set_cookie_header)
+        self.assertIn("Max-Age=0", set_cookie_header)
 
 
 class TestScalekitAuthFastAPIConstruction(unittest.TestCase):

--- a/tests/test_middleware_fastapi.py
+++ b/tests/test_middleware_fastapi.py
@@ -1,0 +1,228 @@
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from scalekit.frameworks.fastapi import ScalekitAuth
+from scalekit.middleware.session_crypto import decrypt_session
+
+
+def _build_app(client=None, secret="fastapi-test-secret", **auth_kwargs):
+    app = FastAPI()
+    mock_client = client or MagicMock()
+    auth = ScalekitAuth(
+        client=mock_client,
+        redirect_uri="https://app.example.com/callback",
+        cookie_encryption_secret=secret,
+        **auth_kwargs,
+    )
+    auth.install(app)
+
+    @app.get("/account")
+    async def account(user: dict = Depends(auth.requires_auth)):
+        return {"email": user["email"]}
+
+    return app, auth, mock_client
+
+
+class TestScalekitAuthFastAPI(unittest.TestCase):
+    def test_login_redirects_to_authorization_url(self):
+        app, auth, client = _build_app()
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize?client_id=x"
+
+        with TestClient(app) as tc:
+            resp = tc.get("/login", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
+
+    def test_callback_sets_encrypted_cookie_and_redirects(self):
+        app, auth, client = _build_app(secret="callback-secret")
+        client.authenticate_with_code.return_value = {
+            "user": {"email": "test.user@example.com"},
+            "access_token": "at_1",
+            "refresh_token": "rt_1",
+            "id_token": "idt_1",
+            "expires_in": 300,
+        }
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+
+        with TestClient(app) as tc:
+            resp = tc.get("/callback?code=abc123", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        set_cookie_header = resp.headers.get("set-cookie", "")
+        self.assertIn("sk_session=", set_cookie_header)
+        self.assertIn("HttpOnly", set_cookie_header)
+        self.assertIn("Secure", set_cookie_header)
+
+    def test_protected_route_without_cookie_redirects_to_login_not_json_401(self):
+        # Same property tested for Flask: "no valid session" must be a real
+        # redirect a browser follows, not a JSON 401 a background fetch would
+        # silently swallow -- that's exactly the failure mode behind the
+        # forced-logout incident this feature was motivated by.
+        app, auth, client = _build_app()
+
+        with TestClient(app) as tc:
+            resp = tc.get("/account", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        self.assertNotEqual(resp.headers.get("content-type"), "application/json")
+
+    def test_protected_route_with_valid_session_succeeds(self):
+        app, auth, client = _build_app(secret="valid-session-secret")
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with TestClient(app) as tc:
+            tc.cookies.set("sk_session", cookie_value)
+            resp = tc.get("/account")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["email"], "test.user@example.com")
+        client.refresh_access_token.assert_not_called()
+
+    def test_protected_route_with_expired_session_refreshes_transparently(self):
+        app, auth, client = _build_app(secret="expired-session-secret")
+        client.refresh_access_token.return_value = {
+            "access_token": "at_new",
+            "refresh_token": "rt_new",
+        }
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_old",
+                "refresh_token": "rt_old",
+                "expires_at": time.time() - 10,
+            }
+        )
+
+        with TestClient(app) as tc:
+            tc.cookies.set("sk_session", cookie_value)
+            resp = tc.get("/account")
+
+        self.assertEqual(resp.status_code, 200)
+        client.refresh_access_token.assert_called_once_with("rt_old")
+
+        set_cookie_header = resp.headers.get("set-cookie", "")
+        self.assertIn("sk_session=", set_cookie_header)
+        new_cookie_value = resp.cookies.get("sk_session")  # this response's cookie, not the client-wide jar
+        new_payload = decrypt_session(new_cookie_value, "expired-session-secret")
+        self.assertEqual(new_payload["access_token"], "at_new")
+
+    def test_protected_route_with_failed_refresh_clears_cookie_and_redirects(self):
+        app, auth, client = _build_app(secret="failed-refresh-secret")
+        client.refresh_access_token.side_effect = Exception("invalid_grant")
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "user@example.com"},
+                "access_token": "at_old",
+                "refresh_token": "rt_old",
+                "expires_at": time.time() - 10,
+            }
+        )
+
+        with TestClient(app) as tc:
+            tc.cookies.set("sk_session", cookie_value)
+            resp = tc.get("/account", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+
+    def test_logout_with_invalid_cookie_falls_back_to_local_redirect(self):
+        app, auth, client = _build_app()
+
+        with TestClient(app) as tc:
+            tc.cookies.set("sk_session", "some-value")
+            resp = tc.get("/logout", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        client.get_logout_url.assert_not_called()
+
+    def test_logout_without_any_cookie_falls_back_to_local_redirect(self):
+        app, auth, client = _build_app()
+
+        with TestClient(app) as tc:
+            resp = tc.get("/logout", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        client.get_logout_url.assert_not_called()
+
+    def test_logout_with_valid_session_does_full_logout_via_id_token_hint(self):
+        app, auth, client = _build_app(secret="full-logout-secret")
+        client.get_logout_url.return_value = "https://auth.example.com/oidc/logout?id_token_hint=abc"
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "id_token": "idt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with TestClient(app) as tc:
+            tc.cookies.set("sk_session", cookie_value)
+            resp = tc.get("/logout", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "https://auth.example.com/oidc/logout?id_token_hint=abc")
+        set_cookie_header = resp.headers.get("set-cookie", "")
+        self.assertIn("sk_session=", set_cookie_header)
+
+        call_options = client.get_logout_url.call_args[0][0]
+        self.assertEqual(call_options.id_token_hint, "idt_1")
+        self.assertTrue(call_options.post_logout_redirect_uri.startswith("http://"))
+
+    def test_full_logout_disabled_does_local_only_logout(self):
+        app, auth, client = _build_app(secret="local-only-secret", full_logout=False)
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "id_token": "idt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with TestClient(app) as tc:
+            tc.cookies.set("sk_session", cookie_value)
+            resp = tc.get("/logout", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        client.get_logout_url.assert_not_called()
+
+
+class TestScalekitAuthFastAPIConstruction(unittest.TestCase):
+    def test_missing_cookie_secret_raises_immediately(self):
+        with self.assertRaises(ValueError):
+            ScalekitAuth(
+                client=MagicMock(),
+                redirect_uri="https://app.example.com/callback",
+                cookie_encryption_secret="",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_middleware_flask.py
+++ b/tests/test_middleware_flask.py
@@ -184,7 +184,7 @@ class TestScalekitAuthFlask(unittest.TestCase):
             resp = tc.get("/account", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.headers["Location"], "/login")
+        self.assertEqual(resp.headers["Location"], "/login?returnTo=%2Faccount")
         self.assertNotEqual(resp.content_type, "application/json")
 
     def test_protected_route_with_valid_session_succeeds(self):
@@ -255,7 +255,7 @@ class TestScalekitAuthFlask(unittest.TestCase):
             resp = tc.get("/account", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.headers["Location"], "/login")
+        self.assertEqual(resp.headers["Location"], "/login?returnTo=%2Faccount")
 
     def test_logout_with_invalid_cookie_falls_back_to_local_redirect(self):
         app, auth, client = _build_app()
@@ -420,6 +420,137 @@ class TestScalekitAuthConstruction(unittest.TestCase):
                 redirect_uri="https://app.example.com/callback",
                 cookie_encryption_secret="",
             )
+
+    def test_missing_redirect_uri_raises_immediately(self):
+        app = Flask(__name__)
+        with self.assertRaises(ValueError):
+            ScalekitAuth(
+                app,
+                client=MagicMock(),
+                cookie_encryption_secret="some-secret",
+            )
+
+
+class TestScalekitAuthReturnTo(unittest.TestCase):
+    def test_login_redirect_round_trips_back_to_originally_requested_page(self):
+        app, auth, client = _build_app(secret="return-to-secret")
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+        client.authenticate_with_code.return_value = {
+            "user": {"email": "test.user@example.com"},
+            "access_token": "at_1",
+            "refresh_token": "rt_1",
+            "id_token": "idt_1",
+            "expires_in": 300,
+        }
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+
+        with app.test_client() as tc:
+            gate_resp = tc.get("/account", follow_redirects=False)
+            self.assertEqual(gate_resp.headers["Location"], "/login?returnTo=%2Faccount")
+
+            login_resp = tc.get(gate_resp.headers["Location"], follow_redirects=False)
+            state = tc.get_cookie("sk_oauth_state").value
+            self.assertEqual(tc.get_cookie("sk_return_to").value, "/account")
+
+            callback_resp = tc.get(f"/callback?code=abc123&state={state}", follow_redirects=False)
+
+        self.assertEqual(callback_resp.status_code, 302)
+        self.assertEqual(callback_resp.headers["Location"], "/account")
+        # one-time-use: cleared after the round trip completes
+        self.assertIsNone(tc.get_cookie("sk_return_to"))
+
+    def test_login_rejects_absolute_url_return_to_falls_back_to_default(self):
+        app, auth, client = _build_app(secret="open-redirect-secret")
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+        client.authenticate_with_code.return_value = {
+            "user": {"email": "test.user@example.com"},
+            "access_token": "at_1",
+            "expires_in": 300,
+        }
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
+
+        with app.test_client() as tc:
+            tc.get("/login?returnTo=https://evil.com", follow_redirects=False)
+            self.assertIsNone(tc.get_cookie("sk_return_to"))
+            state = tc.get_cookie("sk_oauth_state").value
+            resp = tc.get(f"/callback?code=abc123&state={state}", follow_redirects=False)
+
+        self.assertEqual(resp.headers["Location"], "/")
+
+
+class TestScalekitAuthGetSession(unittest.TestCase):
+    def test_get_session_returns_curated_user_and_expiry_for_valid_cookie(self):
+        app, auth, client = _build_app(secret="get-session-secret")
+        expires_at = time.time() + 3600
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "id_token": "idt_1",
+                "expires_at": expires_at,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+
+            @app.route("/whoami")
+            def whoami():
+                session = auth.get_session()
+                return {"session": session}
+
+            resp = tc.get("/whoami")
+
+        self.assertEqual(
+            resp.json["session"],
+            {"user": {"email": "test.user@example.com"}, "expires_at": expires_at},
+        )
+
+    def test_get_session_returns_none_for_missing_cookie(self):
+        app, auth, client = _build_app(secret="get-session-secret-2")
+
+        with app.test_client() as tc:
+
+            @app.route("/whoami")
+            def whoami():
+                return {"session": auth.get_session()}
+
+            resp = tc.get("/whoami")
+
+        self.assertIsNone(resp.json["session"])
+
+    def test_get_session_returns_none_for_tampered_cookie(self):
+        app, auth, client = _build_app(secret="get-session-secret-3")
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", "garbage-not-a-real-cookie")
+
+            @app.route("/whoami")
+            def whoami():
+                return {"session": auth.get_session()}
+
+            resp = tc.get("/whoami")
+
+        self.assertIsNone(resp.json["session"])
+
+
+class TestScalekitAuthCookieSecure(unittest.TestCase):
+    def test_cookie_secure_false_omits_secure_attribute_for_local_http_dev(self):
+        app, auth, client = _build_app(secret="cookie-secure-secret", cookie_secure=False)
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+
+        with app.test_client() as tc:
+            resp = tc.get("/login", follow_redirects=False)
+
+        set_cookie_header = resp.headers.get("Set-Cookie", "")
+        self.assertNotIn("Secure", set_cookie_header)
 
 
 if __name__ == "__main__":

--- a/tests/test_middleware_flask.py
+++ b/tests/test_middleware_flask.py
@@ -8,7 +8,7 @@ from scalekit.frameworks.flask import ScalekitAuth
 from scalekit.middleware.session_crypto import decrypt_session
 
 
-def _build_app(client=None, secret="flask-test-secret"):
+def _build_app(client=None, secret="flask-test-secret", **auth_kwargs):
     app = Flask(__name__)
     app.testing = True
     mock_client = client or MagicMock()
@@ -17,6 +17,7 @@ def _build_app(client=None, secret="flask-test-secret"):
         client=mock_client,
         redirect_uri="https://app.example.com/callback",
         cookie_encryption_secret=secret,
+        **auth_kwargs,
     )
 
     @app.route("/account")
@@ -41,10 +42,15 @@ class TestScalekitAuthFlask(unittest.TestCase):
     def test_callback_sets_encrypted_cookie_and_redirects(self):
         app, auth, client = _build_app(secret="callback-secret")
         client.authenticate_with_code.return_value = {
-            "user": {"email": "alper.gondiken@bloomreach.com"},
+            "user": {"email": "test.user@example.com"},
             "access_token": "at_1",
             "refresh_token": "rt_1",
+            "id_token": "idt_1",
             "expires_in": 300,
+        }
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
         }
 
         with app.test_client() as tc:
@@ -76,7 +82,7 @@ class TestScalekitAuthFlask(unittest.TestCase):
         app, auth, client = _build_app(secret="valid-session-secret")
         cookie_value = auth.manager.create_session_cookie(
             {
-                "user": {"email": "alper.gondiken@bloomreach.com"},
+                "user": {"email": "test.user@example.com"},
                 "access_token": "at_1",
                 "refresh_token": "rt_1",
                 "expires_at": time.time() + 3600,
@@ -88,7 +94,7 @@ class TestScalekitAuthFlask(unittest.TestCase):
             resp = tc.get("/account")
 
         self.assertEqual(resp.status_code, 200)
-        self.assertIn(b"alper.gondiken@bloomreach.com", resp.data)
+        self.assertIn(b"test.user@example.com", resp.data)
         client.refresh_access_token.assert_not_called()
 
     def test_protected_route_with_expired_session_refreshes_transparently(self):
@@ -96,11 +102,14 @@ class TestScalekitAuthFlask(unittest.TestCase):
         client.refresh_access_token.return_value = {
             "access_token": "at_new",
             "refresh_token": "rt_new",
-            "expires_in": 300,
+        }
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
         }
         cookie_value = auth.manager.create_session_cookie(
             {
-                "user": {"email": "alper.gondiken@bloomreach.com"},
+                "user": {"email": "test.user@example.com"},
                 "access_token": "at_old",
                 "refresh_token": "rt_old",
                 "expires_at": time.time() - 10,
@@ -139,17 +148,76 @@ class TestScalekitAuthFlask(unittest.TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/login")
 
-    def test_logout_clears_cookie_and_redirects(self):
+    def test_logout_with_invalid_cookie_falls_back_to_local_redirect(self):
         app, auth, client = _build_app()
 
         with app.test_client() as tc:
-            tc.set_cookie("sk_session", "some-value")
+            tc.set_cookie("sk_session", "some-value")  # undecryptable garbage
             resp = tc.get("/logout", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
         set_cookie_header = resp.headers.get("Set-Cookie", "")
         self.assertIn("sk_session=", set_cookie_header)
+        client.get_logout_url.assert_not_called()
+
+    def test_logout_without_any_cookie_falls_back_to_local_redirect(self):
+        app, auth, client = _build_app()
+
+        with app.test_client() as tc:
+            resp = tc.get("/logout", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        client.get_logout_url.assert_not_called()
+
+    def test_logout_with_valid_session_does_full_logout_via_id_token_hint(self):
+        app, auth, client = _build_app(secret="full-logout-secret")
+        client.get_logout_url.return_value = "https://auth.example.com/oidc/logout?id_token_hint=abc"
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "id_token": "idt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+            resp = tc.get("/logout", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "https://auth.example.com/oidc/logout?id_token_hint=abc")
+        set_cookie_header = resp.headers.get("Set-Cookie", "")
+        self.assertIn("sk_session=", set_cookie_header)  # local cookie still cleared too
+
+        call_options = client.get_logout_url.call_args[0][0]
+        self.assertEqual(call_options.id_token_hint, "idt_1")
+        # Scalekit requires an absolute, allow-listed post-logout redirect URI --
+        # a bare "/" gets absolutized against the request's own host.
+        self.assertEqual(call_options.post_logout_redirect_uri, "http://localhost/")
+
+    def test_full_logout_disabled_does_local_only_logout(self):
+        app, auth, client = _build_app(secret="local-only-secret", full_logout=False)
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "id_token": "idt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+            resp = tc.get("/logout", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        client.get_logout_url.assert_not_called()
 
 
 class TestScalekitAuthConstruction(unittest.TestCase):

--- a/tests/test_middleware_flask.py
+++ b/tests/test_middleware_flask.py
@@ -66,6 +66,42 @@ class TestScalekitAuthFlask(unittest.TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
 
+    def test_login_with_idp_initiated_login_uses_claims_for_authorization_url(self):
+        # /login doubles as the dashboard-registered "Initiate Login URL" --
+        # Scalekit can land users here with an idp_initiated_login JWT (e.g.
+        # an IdP portal tile click with an active session) instead of the
+        # plain no-params hit.
+        app, auth, client = _build_app()
+        client.get_idp_initiated_login_claims.return_value = {
+            "connection_id": "conn_123",
+            "organization_id": "org_456",
+            "login_hint": "user@example.com",
+        }
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize?client_id=x"
+
+        with app.test_client() as tc:
+            resp = tc.get("/login?idp_initiated_login=some.jwt.token", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        client.get_idp_initiated_login_claims.assert_called_once_with("some.jwt.token")
+        call_options = client.get_authorization_url.call_args[0][1]
+        self.assertEqual(call_options.connection_id, "conn_123")
+        self.assertEqual(call_options.organization_id, "org_456")
+        self.assertEqual(call_options.login_hint, "user@example.com")
+
+    def test_login_with_invalid_idp_initiated_login_falls_back_to_normal_login(self):
+        app, auth, client = _build_app()
+        client.get_idp_initiated_login_claims.side_effect = Exception("invalid token")
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize?client_id=x"
+
+        with app.test_client() as tc:
+            resp = tc.get("/login?idp_initiated_login=garbage", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
+        call_options = client.get_authorization_url.call_args[0][1]
+        self.assertIsNone(call_options.connection_id)
+
     def test_callback_sets_encrypted_cookie_and_redirects(self):
         app, auth, client = _build_app(secret="callback-secret")
         client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"

--- a/tests/test_middleware_flask.py
+++ b/tests/test_middleware_flask.py
@@ -2,7 +2,7 @@ import time
 import unittest
 from unittest.mock import MagicMock
 
-from flask import Flask
+from flask import Flask, jsonify, redirect
 
 from scalekit.frameworks.flask import ScalekitAuth
 from scalekit.middleware.session_crypto import decrypt_session
@@ -25,7 +25,34 @@ def _build_app(client=None, secret="flask-test-secret", **auth_kwargs):
     def account():
         return f"hello {auth.current_user['email']}"
 
+    @app.route("/account-json")
+    @auth.requires_auth
+    def account_json():
+        return {"email": auth.current_user["email"]}
+
+    @app.route("/account-tuple")
+    @auth.requires_auth
+    def account_tuple():
+        return "created", 201
+
+    @app.route("/account-jsonify")
+    @auth.requires_auth
+    def account_jsonify():
+        return jsonify(email=auth.current_user["email"])
+
+    @app.route("/account-redirect")
+    @auth.requires_auth
+    def account_redirect():
+        return redirect("/somewhere-else")
+
     return app, auth, mock_client
+
+
+def _login_and_get_state(tc):
+    """Drive /login through the test client to obtain a valid state cookie,
+    exactly as a real browser would before hitting /callback."""
+    tc.get("/login", follow_redirects=False)
+    return tc.get_cookie("sk_oauth_state").value
 
 
 class TestScalekitAuthFlask(unittest.TestCase):
@@ -41,6 +68,7 @@ class TestScalekitAuthFlask(unittest.TestCase):
 
     def test_callback_sets_encrypted_cookie_and_redirects(self):
         app, auth, client = _build_app(secret="callback-secret")
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
         client.authenticate_with_code.return_value = {
             "user": {"email": "test.user@example.com"},
             "access_token": "at_1",
@@ -54,7 +82,8 @@ class TestScalekitAuthFlask(unittest.TestCase):
         }
 
         with app.test_client() as tc:
-            resp = tc.get("/callback?code=abc123", follow_redirects=False)
+            state = _login_and_get_state(tc)
+            resp = tc.get(f"/callback?code=abc123&state={state}", follow_redirects=False)
 
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
@@ -63,6 +92,50 @@ class TestScalekitAuthFlask(unittest.TestCase):
         self.assertIn("HttpOnly", set_cookie_header)
         self.assertIn("Secure", set_cookie_header)
         self.assertIn("SameSite=Lax", set_cookie_header)
+
+    def test_callback_with_provider_error_redirects_to_login_not_500(self):
+        app, auth, client = _build_app()
+
+        with app.test_client() as tc:
+            resp = tc.get("/callback?error=access_denied", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        client.authenticate_with_code.assert_not_called()
+
+    def test_callback_with_missing_code_redirects_to_login(self):
+        app, auth, client = _build_app()
+
+        with app.test_client() as tc:
+            resp = tc.get("/callback", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        client.authenticate_with_code.assert_not_called()
+
+    def test_callback_with_missing_state_redirects_to_login(self):
+        # No /login call at all -- no state cookie exists, simulating a
+        # forged callback URL sent directly to a victim.
+        app, auth, client = _build_app()
+
+        with app.test_client() as tc:
+            resp = tc.get("/callback?code=abc123&state=whatever", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        client.authenticate_with_code.assert_not_called()
+
+    def test_callback_with_mismatched_state_redirects_to_login(self):
+        app, auth, client = _build_app()
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize"
+
+        with app.test_client() as tc:
+            _login_and_get_state(tc)
+            resp = tc.get("/callback?code=abc123&state=attacker-supplied", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        client.authenticate_with_code.assert_not_called()
 
     def test_protected_route_without_cookie_redirects_to_login_not_json_401(self):
         # This is the exact property whose absence caused the forced-logout
@@ -158,7 +231,10 @@ class TestScalekitAuthFlask(unittest.TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
         set_cookie_header = resp.headers.get("Set-Cookie", "")
-        self.assertIn("sk_session=", set_cookie_header)
+        # Assert the cookie is actually cleared, not merely present -- "sk_session="
+        # alone would also match a freshly re-issued valid cookie.
+        self.assertIn("sk_session=;", set_cookie_header)
+        self.assertIn("Expires=Thu, 01 Jan 1970", set_cookie_header)
         client.get_logout_url.assert_not_called()
 
     def test_logout_without_any_cookie_falls_back_to_local_redirect(self):
@@ -191,7 +267,9 @@ class TestScalekitAuthFlask(unittest.TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "https://auth.example.com/oidc/logout?id_token_hint=abc")
         set_cookie_header = resp.headers.get("Set-Cookie", "")
-        self.assertIn("sk_session=", set_cookie_header)  # local cookie still cleared too
+        # local cookie is actually cleared too, not just present/reissued
+        self.assertIn("sk_session=;", set_cookie_header)
+        self.assertIn("Expires=Thu, 01 Jan 1970", set_cookie_header)
 
         call_options = client.get_logout_url.call_args[0][0]
         self.assertEqual(call_options.id_token_hint, "idt_1")
@@ -218,6 +296,82 @@ class TestScalekitAuthFlask(unittest.TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.headers["Location"], "/")
         client.get_logout_url.assert_not_called()
+        set_cookie_header = resp.headers.get("Set-Cookie", "")
+        self.assertIn("sk_session=;", set_cookie_header)
+        self.assertIn("Expires=Thu, 01 Jan 1970", set_cookie_header)
+
+    def test_requires_auth_preserves_dict_return_as_json(self):
+        app, auth, client = _build_app(secret="return-type-secret")
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+            resp = tc.get("/account-json")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json, {"email": "test.user@example.com"})
+
+    def test_requires_auth_preserves_status_code_tuple_return(self):
+        app, auth, client = _build_app(secret="return-type-secret-2")
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+            resp = tc.get("/account-tuple")
+
+        self.assertEqual(resp.status_code, 201)
+        self.assertEqual(resp.data, b"created")
+
+    def test_requires_auth_preserves_jsonify_content_type(self):
+        app, auth, client = _build_app(secret="return-type-secret-3")
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+            resp = tc.get("/account-jsonify")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content_type, "application/json")
+        self.assertEqual(resp.json, {"email": "test.user@example.com"})
+
+    def test_requires_auth_preserves_redirect_return(self):
+        app, auth, client = _build_app(secret="return-type-secret-4")
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "test.user@example.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+            resp = tc.get("/account-redirect", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/somewhere-else")
 
 
 class TestScalekitAuthConstruction(unittest.TestCase):

--- a/tests/test_middleware_flask.py
+++ b/tests/test_middleware_flask.py
@@ -1,0 +1,168 @@
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from flask import Flask
+
+from scalekit.frameworks.flask import ScalekitAuth
+from scalekit.middleware.session_crypto import decrypt_session
+
+
+def _build_app(client=None, secret="flask-test-secret"):
+    app = Flask(__name__)
+    app.testing = True
+    mock_client = client or MagicMock()
+    auth = ScalekitAuth(
+        app,
+        client=mock_client,
+        redirect_uri="https://app.example.com/callback",
+        cookie_encryption_secret=secret,
+    )
+
+    @app.route("/account")
+    @auth.requires_auth
+    def account():
+        return f"hello {auth.current_user['email']}"
+
+    return app, auth, mock_client
+
+
+class TestScalekitAuthFlask(unittest.TestCase):
+    def test_login_redirects_to_authorization_url(self):
+        app, auth, client = _build_app()
+        client.get_authorization_url.return_value = "https://auth.example.com/oauth/authorize?client_id=x"
+
+        with app.test_client() as tc:
+            resp = tc.get("/login", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "https://auth.example.com/oauth/authorize?client_id=x")
+
+    def test_callback_sets_encrypted_cookie_and_redirects(self):
+        app, auth, client = _build_app(secret="callback-secret")
+        client.authenticate_with_code.return_value = {
+            "user": {"email": "alper.gondiken@bloomreach.com"},
+            "access_token": "at_1",
+            "refresh_token": "rt_1",
+            "expires_in": 300,
+        }
+
+        with app.test_client() as tc:
+            resp = tc.get("/callback?code=abc123", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        set_cookie_header = resp.headers.get("Set-Cookie", "")
+        self.assertIn("sk_session=", set_cookie_header)
+        self.assertIn("HttpOnly", set_cookie_header)
+        self.assertIn("Secure", set_cookie_header)
+        self.assertIn("SameSite=Lax", set_cookie_header)
+
+    def test_protected_route_without_cookie_redirects_to_login_not_json_401(self):
+        # This is the exact property whose absence caused the forced-logout
+        # incident this feature is motivated by: on "no valid session," the
+        # response must be a real redirect a browser will follow, not a JSON
+        # 401 a background fetch/XHR would silently swallow.
+        app, auth, client = _build_app()
+
+        with app.test_client() as tc:
+            resp = tc.get("/account", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+        self.assertNotEqual(resp.content_type, "application/json")
+
+    def test_protected_route_with_valid_session_succeeds(self):
+        app, auth, client = _build_app(secret="valid-session-secret")
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "alper.gondiken@bloomreach.com"},
+                "access_token": "at_1",
+                "refresh_token": "rt_1",
+                "expires_at": time.time() + 3600,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+            resp = tc.get("/account")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn(b"alper.gondiken@bloomreach.com", resp.data)
+        client.refresh_access_token.assert_not_called()
+
+    def test_protected_route_with_expired_session_refreshes_transparently(self):
+        app, auth, client = _build_app(secret="expired-session-secret")
+        client.refresh_access_token.return_value = {
+            "access_token": "at_new",
+            "refresh_token": "rt_new",
+            "expires_in": 300,
+        }
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "alper.gondiken@bloomreach.com"},
+                "access_token": "at_old",
+                "refresh_token": "rt_old",
+                "expires_at": time.time() - 10,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+            resp = tc.get("/account")
+
+        self.assertEqual(resp.status_code, 200)
+        client.refresh_access_token.assert_called_once_with("rt_old")
+
+        set_cookie_header = resp.headers.get("Set-Cookie", "")
+        self.assertIn("sk_session=", set_cookie_header)
+        new_cookie_value = tc.get_cookie("sk_session").value
+        new_payload = decrypt_session(new_cookie_value, "expired-session-secret")
+        self.assertEqual(new_payload["access_token"], "at_new")
+
+    def test_protected_route_with_failed_refresh_clears_cookie_and_redirects(self):
+        app, auth, client = _build_app(secret="failed-refresh-secret")
+        client.refresh_access_token.side_effect = Exception("invalid_grant")
+        cookie_value = auth.manager.create_session_cookie(
+            {
+                "user": {"email": "user@example.com"},
+                "access_token": "at_old",
+                "refresh_token": "rt_old",
+                "expires_at": time.time() - 10,
+            }
+        )
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", cookie_value)
+            resp = tc.get("/account", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/login")
+
+    def test_logout_clears_cookie_and_redirects(self):
+        app, auth, client = _build_app()
+
+        with app.test_client() as tc:
+            tc.set_cookie("sk_session", "some-value")
+            resp = tc.get("/logout", follow_redirects=False)
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.headers["Location"], "/")
+        set_cookie_header = resp.headers.get("Set-Cookie", "")
+        self.assertIn("sk_session=", set_cookie_header)
+
+
+class TestScalekitAuthConstruction(unittest.TestCase):
+    def test_missing_cookie_secret_raises_immediately(self):
+        app = Flask(__name__)
+        with self.assertRaises(ValueError):
+            ScalekitAuth(
+                app,
+                client=MagicMock(),
+                redirect_uri="https://app.example.com/callback",
+                cookie_encryption_secret="",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_middleware_session_crypto.py
+++ b/tests/test_middleware_session_crypto.py
@@ -12,7 +12,7 @@ class TestSessionCrypto(unittest.TestCase):
     def setUp(self):
         self.secret = "correct-horse-battery-staple-secret"
         self.payload = {
-            "user": {"email": "alper.gondiken@bloomreach.com"},
+            "user": {"email": "test.user@example.com"},
             "access_token": "at_123",
             "refresh_token": "rt_456",
             "expires_at": 9999999999,

--- a/tests/test_middleware_session_crypto.py
+++ b/tests/test_middleware_session_crypto.py
@@ -1,0 +1,76 @@
+import base64
+import unittest
+
+from scalekit.middleware.session_crypto import (
+    InvalidSessionError,
+    decrypt_session,
+    encrypt_session,
+)
+
+
+class TestSessionCrypto(unittest.TestCase):
+    def setUp(self):
+        self.secret = "correct-horse-battery-staple-secret"
+        self.payload = {
+            "user": {"email": "alper.gondiken@bloomreach.com"},
+            "access_token": "at_123",
+            "refresh_token": "rt_456",
+            "expires_at": 9999999999,
+        }
+
+    def test_round_trip(self):
+        token = encrypt_session(self.payload, self.secret)
+        decrypted = decrypt_session(token, self.secret)
+        self.assertEqual(decrypted, self.payload)
+
+    def test_tampered_ciphertext_fails_to_decrypt(self):
+        token = encrypt_session(self.payload, self.secret)
+        raw = bytearray(base64.urlsafe_b64decode(token + "=" * (-len(token) % 4)))
+        # flip a bit well inside the ciphertext (past version byte + nonce)
+        raw[-1] ^= 0xFF
+        tampered = base64.urlsafe_b64encode(bytes(raw)).decode("ascii").rstrip("=")
+
+        with self.assertRaises(InvalidSessionError):
+            decrypt_session(tampered, self.secret)
+
+    def test_wrong_secret_fails_to_decrypt(self):
+        token = encrypt_session(self.payload, self.secret)
+        with self.assertRaises(InvalidSessionError):
+            decrypt_session(token, "a-completely-different-secret")
+
+    def test_missing_secret_raises_on_encrypt(self):
+        with self.assertRaises(ValueError):
+            encrypt_session(self.payload, "")
+
+    def test_missing_secret_raises_on_decrypt(self):
+        token = encrypt_session(self.payload, self.secret)
+        with self.assertRaises(ValueError):
+            decrypt_session(token, "")
+
+    def test_missing_token_raises_invalid_session(self):
+        with self.assertRaises(InvalidSessionError):
+            decrypt_session("", self.secret)
+
+    def test_malformed_token_raises_invalid_session_not_crash(self):
+        with self.assertRaises(InvalidSessionError):
+            decrypt_session("not-a-valid-base64url-token!!!", self.secret)
+
+    def test_unsupported_version_byte_raises_invalid_session(self):
+        token = encrypt_session(self.payload, self.secret)
+        raw = bytearray(base64.urlsafe_b64decode(token + "=" * (-len(token) % 4)))
+        raw[0] = 99  # bogus version
+        bogus_version_token = base64.urlsafe_b64encode(bytes(raw)).decode("ascii").rstrip("=")
+
+        with self.assertRaises(InvalidSessionError):
+            decrypt_session(bogus_version_token, self.secret)
+
+    def test_different_secrets_produce_non_decryptable_cross_over(self):
+        # Simulates two server instances with mismatched secrets -- must fail
+        # cleanly (InvalidSessionError), never crash, never silently succeed.
+        token_a = encrypt_session(self.payload, "secret-a")
+        with self.assertRaises(InvalidSessionError):
+            decrypt_session(token_a, "secret-b")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_middleware_session_crypto.py
+++ b/tests/test_middleware_session_crypto.py
@@ -71,6 +71,16 @@ class TestSessionCrypto(unittest.TestCase):
         with self.assertRaises(InvalidSessionError):
             decrypt_session(token_a, "secret-b")
 
+    def test_oversized_payload_raises_instead_of_silently_dropping(self):
+        # Browsers silently drop cookies over ~4096 bytes -- a customer with
+        # many custom access-token claims could hit this. Must fail loudly at
+        # encrypt time instead of producing a cookie the browser discards.
+        oversized_payload = dict(self.payload)
+        oversized_payload["user"] = {"claim": "x" * 4000}
+
+        with self.assertRaises(ValueError):
+            encrypt_session(oversized_payload, self.secret)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_middleware_session_manager.py
+++ b/tests/test_middleware_session_manager.py
@@ -1,0 +1,160 @@
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from scalekit.middleware.session_crypto import decrypt_session, encrypt_session
+from scalekit.middleware.session_manager import SessionRefreshManager
+
+
+class _FakeRequest:
+    def __init__(self, cookie_value=None):
+        self._cookie_value = cookie_value
+
+    def get_cookie(self, name):
+        return self._cookie_value
+
+    def get_request_url(self):
+        return "https://app.example.com/account"
+
+
+class TestSessionRefreshManagerConstruction(unittest.TestCase):
+    def test_missing_secret_raises_immediately(self):
+        with self.assertRaises(ValueError):
+            SessionRefreshManager(client=MagicMock(), cookie_encryption_secret="")
+
+
+class TestSessionRefreshManagerCheck(unittest.TestCase):
+    def setUp(self):
+        self.secret = "test-secret-for-manager"
+        self.client = MagicMock()
+        self.manager = SessionRefreshManager(self.client, self.secret)
+
+    def _cookie_for(self, expires_at, refresh_token="rt_original"):
+        payload = {
+            "user": {"email": "user@example.com"},
+            "access_token": "at_old",
+            "refresh_token": refresh_token,
+            "expires_at": expires_at,
+        }
+        return encrypt_session(payload, self.secret)
+
+    def test_no_cookie_present(self):
+        result = self.manager.check(_FakeRequest(cookie_value=None))
+        self.assertFalse(result.authenticated)
+        self.assertEqual(result.reason, "no_session")
+        self.assertFalse(result.should_clear_cookie)
+
+    def test_malformed_cookie_is_invalid_session(self):
+        result = self.manager.check(_FakeRequest(cookie_value="garbage-not-a-real-token"))
+        self.assertFalse(result.authenticated)
+        self.assertEqual(result.reason, "invalid_session")
+        self.assertTrue(result.should_clear_cookie)
+
+    def test_valid_unexpired_session_passes_through_without_refresh(self):
+        cookie = self._cookie_for(expires_at=time.time() + 3600)
+        result = self.manager.check(_FakeRequest(cookie_value=cookie))
+
+        self.assertTrue(result.authenticated)
+        self.assertEqual(result.user, {"email": "user@example.com"})
+        self.assertIsNone(result.new_cookie_value)
+        self.client.refresh_access_token.assert_not_called()
+
+    def test_expired_session_triggers_refresh_and_returns_new_cookie(self):
+        self.client.refresh_access_token.return_value = {
+            "access_token": "at_new",
+            "refresh_token": "rt_new",
+            "expires_in": 300,
+        }
+        cookie = self._cookie_for(expires_at=time.time() - 10)  # already expired
+
+        result = self.manager.check(_FakeRequest(cookie_value=cookie))
+
+        self.assertTrue(result.authenticated)
+        self.assertIsNotNone(result.new_cookie_value)
+        self.client.refresh_access_token.assert_called_once_with("rt_original")
+
+        new_payload = decrypt_session(result.new_cookie_value, self.secret)
+        self.assertEqual(new_payload["access_token"], "at_new")
+        self.assertEqual(new_payload["refresh_token"], "rt_new")
+
+    def test_refresh_failure_clears_cookie_and_redirects(self):
+        self.client.refresh_access_token.side_effect = Exception("invalid_grant")
+        cookie = self._cookie_for(expires_at=time.time() - 10)
+
+        result = self.manager.check(_FakeRequest(cookie_value=cookie))
+
+        self.assertFalse(result.authenticated)
+        self.assertTrue(result.should_clear_cookie)
+        self.assertEqual(result.reason, "refresh_failed")
+
+    def test_expired_session_with_no_refresh_token_is_invalid(self):
+        payload_cookie = encrypt_session(
+            {"user": {}, "access_token": "at_old", "refresh_token": None, "expires_at": time.time() - 10},
+            self.secret,
+        )
+        result = self.manager.check(_FakeRequest(cookie_value=payload_cookie))
+
+        self.assertFalse(result.authenticated)
+        self.assertTrue(result.should_clear_cookie)
+        self.client.refresh_access_token.assert_not_called()
+
+
+class TestSessionRefreshManagerConcurrency(unittest.TestCase):
+    """
+    Proves the singleflight lock actually coalesces concurrent refresh attempts
+    for the same (expired) session into a single real network call -- this is
+    the exact race condition behind the forced-logout investigation this
+    feature was motivated by.
+    """
+
+    def test_concurrent_requests_for_same_session_trigger_one_refresh_call(self):
+        secret = "concurrency-test-secret"
+        client = MagicMock()
+        call_count_lock = threading.Lock()
+        call_count = {"n": 0}
+
+        def slow_refresh(refresh_token):
+            with call_count_lock:
+                call_count["n"] += 1
+            time.sleep(0.05)  # simulate network latency, widening the race window
+            return {"access_token": "at_new", "refresh_token": "rt_new", "expires_in": 300}
+
+        client.refresh_access_token.side_effect = slow_refresh
+        manager = SessionRefreshManager(client, secret)
+
+        cookie = encrypt_session(
+            {
+                "user": {"email": "alper@example.com"},
+                "access_token": "at_old",
+                "refresh_token": "rt_shared",
+                "expires_at": time.time() - 10,
+            },
+            secret,
+        )
+
+        results = []
+        results_lock = threading.Lock()
+
+        def worker():
+            result = manager.check(_FakeRequest(cookie_value=cookie))
+            with results_lock:
+                results.append(result)
+
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        self.assertEqual(len(results), 20)
+        self.assertEqual(
+            call_count["n"], 1, "expected exactly one real refresh call across 20 concurrent requests"
+        )
+        for result in results:
+            self.assertTrue(result.authenticated)
+            self.assertIsNotNone(result.new_cookie_value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_middleware_session_manager.py
+++ b/tests/test_middleware_session_manager.py
@@ -250,6 +250,38 @@ class TestSessionRefreshManagerConcurrency(unittest.TestCase):
         self.assertIsNotNone(second.new_cookie_value)
         self.assertEqual(attempts["n"], 2, "the second check() must actually retry, not reuse a cached failure")
 
+    def test_lock_entry_is_cleaned_up_after_an_uncached_failed_refresh(self):
+        """
+        A failed refresh is deliberately never cached (see _refresh). Without
+        also removing the lock entry once the last holder releases it,
+        _sweep_expired_locked would never clean it up either -- it only
+        considers keys present in _refresh_cache -- so every distinct
+        refresh_token that ever fails would leak a _LockEntry forever.
+        """
+        client = MagicMock()
+        client.refresh_access_token.side_effect = Exception("invalid_grant")
+        secret = "lock-leak-secret"
+        manager = SessionRefreshManager(client, secret)
+        cookie = encrypt_session(
+            {
+                "user": {},
+                "access_token": "at_old",
+                "refresh_token": "rt_dead",
+                "expires_at": time.time() - 10,
+            },
+            secret,
+        )
+
+        result = manager.check(_FakeRequest(cookie_value=cookie))
+
+        self.assertFalse(result.authenticated)
+        self.assertNotIn("rt_dead", manager._refresh_cache)
+        self.assertNotIn(
+            "rt_dead",
+            manager._session_locks,
+            "the lock entry for a permanently-failed, uncached refresh must not leak",
+        )
+
 
 class TestSessionRefreshManagerReadSession(unittest.TestCase):
     def test_read_session_returns_payload_for_valid_cookie(self):

--- a/tests/test_middleware_session_manager.py
+++ b/tests/test_middleware_session_manager.py
@@ -64,7 +64,11 @@ class TestSessionRefreshManagerCheck(unittest.TestCase):
         self.client.refresh_access_token.return_value = {
             "access_token": "at_new",
             "refresh_token": "rt_new",
-            "expires_in": 300,
+        }
+        fresh_expiry = time.time() + 300
+        self.client.validate_access_token_and_get_claims.return_value = {
+            "email": "user@example.com",
+            "exp": fresh_expiry,
         }
         cookie = self._cookie_for(expires_at=time.time() - 10)  # already expired
 
@@ -73,10 +77,14 @@ class TestSessionRefreshManagerCheck(unittest.TestCase):
         self.assertTrue(result.authenticated)
         self.assertIsNotNone(result.new_cookie_value)
         self.client.refresh_access_token.assert_called_once_with("rt_original")
+        self.client.validate_access_token_and_get_claims.assert_called_once_with("at_new")
 
         new_payload = decrypt_session(result.new_cookie_value, self.secret)
         self.assertEqual(new_payload["access_token"], "at_new")
         self.assertEqual(new_payload["refresh_token"], "rt_new")
+        # user/claims must come from the freshly-issued access token, not the old cache
+        self.assertEqual(new_payload["user"], {"email": "user@example.com", "exp": fresh_expiry})
+        self.assertEqual(new_payload["expires_at"], fresh_expiry)
 
     def test_refresh_failure_clears_cookie_and_redirects(self):
         self.client.refresh_access_token.side_effect = Exception("invalid_grant")
@@ -121,11 +129,15 @@ class TestSessionRefreshManagerConcurrency(unittest.TestCase):
             return {"access_token": "at_new", "refresh_token": "rt_new", "expires_in": 300}
 
         client.refresh_access_token.side_effect = slow_refresh
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "test.user@example.com",
+            "exp": time.time() + 300,
+        }
         manager = SessionRefreshManager(client, secret)
 
         cookie = encrypt_session(
             {
-                "user": {"email": "alper@example.com"},
+                "user": {"email": "test.user@example.com"},
                 "access_token": "at_old",
                 "refresh_token": "rt_shared",
                 "expires_at": time.time() - 10,

--- a/tests/test_middleware_session_manager.py
+++ b/tests/test_middleware_session_manager.py
@@ -167,6 +167,105 @@ class TestSessionRefreshManagerConcurrency(unittest.TestCase):
             self.assertTrue(result.authenticated)
             self.assertIsNotNone(result.new_cookie_value)
 
+    def test_sweep_does_not_evict_a_lock_a_caller_is_still_waiting_on(self):
+        """
+        A caller can obtain a lock reference from `_lock_for()` and pause before
+        entering `with lock:`. If the TTL sweep then evicts that key's cache
+        entry/lock out from under it, the paused caller misses the cached
+        success and redundantly re-hits the (already-rotated) refresh_token --
+        which can fail outside Scalekit's rotation grace window and force a
+        needless logout. The sweep must not evict a key while ref_count > 0.
+        """
+        manager = SessionRefreshManager(MagicMock(), "sweep-race-secret")
+        key = "rt_paused_caller"
+
+        # Simulate a paused caller: it already called _lock_for() (ref_count=1)
+        # but hasn't reached `with lock:` yet.
+        manager._lock_for(key)
+
+        # Simulate a completed refresh for this same key, stale enough to be
+        # swept (older than the TTL).
+        from scalekit.middleware.session_manager import _RefreshOutcome, SessionResult
+
+        manager._refresh_cache[key] = _RefreshOutcome(
+            session_result=SessionResult(authenticated=True, user={"email": "user@example.com"}),
+            created_at=time.time() - 1000,  # well past the TTL
+        )
+
+        manager._sweep_expired_locked()
+
+        self.assertIn(
+            key,
+            manager._refresh_cache,
+            "cache entry must survive the sweep while a caller still holds a lock reference",
+        )
+        self.assertIn(key, manager._session_locks)
+
+        # Once the paused caller finishes (releases its reference), a later
+        # sweep is free to clean it up.
+        manager._release_lock_ref(key)
+        manager._sweep_expired_locked()
+        self.assertNotIn(key, manager._refresh_cache)
+        self.assertNotIn(key, manager._session_locks)
+
+    def test_retries_after_a_transient_refresh_failure(self):
+        """
+        A failed refresh must not be cached for the full TTL -- only a
+        successful rotation should be. Otherwise a transient network error
+        (timeout, 503) pins every caller of this session to "logged out" for
+        up to 60s with no chance to retry.
+        """
+        client = MagicMock()
+        attempts = {"n": 0}
+
+        def flaky_refresh(refresh_token):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise Exception("ETIMEDOUT")
+            return {"access_token": "at_new", "refresh_token": "rt_new"}
+
+        client.refresh_access_token.side_effect = flaky_refresh
+        client.validate_access_token_and_get_claims.return_value = {
+            "email": "user@example.com",
+            "exp": time.time() + 300,
+        }
+        secret = "retry-after-failure-secret"
+        manager = SessionRefreshManager(client, secret)
+        cookie = encrypt_session(
+            {
+                "user": {"email": "user@example.com"},
+                "access_token": "at_old",
+                "refresh_token": "rt_shared",
+                "expires_at": time.time() - 10,
+            },
+            secret,
+        )
+
+        first = manager.check(_FakeRequest(cookie_value=cookie))
+        self.assertFalse(first.authenticated)
+        self.assertEqual(first.reason, "refresh_failed")
+
+        second = manager.check(_FakeRequest(cookie_value=cookie))
+        self.assertTrue(second.authenticated)
+        self.assertIsNotNone(second.new_cookie_value)
+        self.assertEqual(attempts["n"], 2, "the second check() must actually retry, not reuse a cached failure")
+
+
+class TestSessionRefreshManagerReadSession(unittest.TestCase):
+    def test_read_session_returns_payload_for_valid_cookie(self):
+        secret = "read-session-secret"
+        manager = SessionRefreshManager(MagicMock(), secret)
+        cookie = encrypt_session({"id_token": "idt_1"}, secret)
+
+        payload = manager.read_session(cookie)
+
+        self.assertEqual(payload, {"id_token": "idt_1"})
+
+    def test_read_session_returns_none_for_invalid_cookie(self):
+        manager = SessionRefreshManager(MagicMock(), "read-session-secret")
+
+        self.assertIsNone(manager.read_session("not-a-valid-cookie"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Squashed into one release (v2.17.0):

1. **Encrypted-session middleware** (SK-1504/SK-1505) — framework-agnostic protocol plus Flask, FastAPI, and Django extras. See original description below.
2. **Security fix** — bumped `cryptography` from `>=46.0.6,<49` to `>=50.0.0` (removed upper bound), fixing a high-severity Dependabot alert (PKCS#7 EnvelopedData Bleichenbacher oracle) affecting `cryptography` 44.0.0–49.x. Previously PR #190, now merged into this branch — #190 is closed as superseded.
3. Version bumped `2.16.0` → `2.17.0`.

---

### 1. Middleware (original description)

- **Core**: encrypted session cookie (AES-256-GCM, versioned wire format, key derived from a required `cookie_encryption_secret` with no hardcoded default), transparent refresh on expiry deriving `user` from freshly-issued **access-token** claims (not id_token, since customers can configure custom access-token claims and only the access token is reissued on refresh), and a threading-lock + TTL-cache singleflight so concurrent requests for the same expired session coalesce into a single real refresh call.
- **Flask/FastAPI/Django extras**: login/callback/logout routes (or views/URLconf, per framework) + a decorator/dependency to protect routes. Each ships as an optional extra (`pip install scalekit-sdk-python[flask]`, `[fastapi]`, `[django]`) — zero framework imports in the base package.
- Full logout via `id_token_hint` (RP-initiated logout), `post_logout_redirect_uri` auto-absolutized against the request host. Defaults to full logout.
- `offline_access` scope requested explicitly at login (required to get a refresh token issued at all for a normal FSA client).

### 2. Backward compatibility

Fully additive aside from the cryptography floor bump — no other core SDK behavior changed. Framework extras are opt-in installs.

## Test plan

- [x] 49 middleware tests passing (session crypto, session manager incl. 20-thread concurrency test, Flask, FastAPI, Django)
- [x] `cryptography==50.0.0` installed and verified (AESGCM + RSA/PEM serialization paths exercised)
- [x] Full test-suite collection (297 tests) with no errors
- [x] Live end-to-end validation against a real Scalekit dev environment for Flask, FastAPI, and Django: login (real OTP) → protected route showing real access-token claims → transparent refresh on expiry → full logout confirmed genuine

Linear: SK-1504, SK-1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentication integrations for Django, FastAPI, and Flask.
  * Added login, callback, logout, protected-route handling, and current-user access.
  * Added encrypted session cookies, automatic session refresh, CSRF protection, and invalid-session cleanup.
  * Added framework-independent session and request/response utilities.
  * Added optional framework installation extras and clearer configuration errors.

* **Documentation**
  * Added setup guidance and runnable examples for all three frameworks.

* **Tests**
  * Added comprehensive coverage for authentication flows, session security, refresh handling, logout, concurrency, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->