### PR TITLE
fix: bump cryptography to >=50.0.0 (high-severity CVE)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "requests>=2.34.0",
         "PyJWT>=2.13.0",
         "cffi>=1.15.1",
-        "cryptography>=46.0.6,<49",
+        "cryptography>=50.0.0",
         "setuptools>=82.0.1,<83.0",
         "grpcio-status>=1.81.0,<2.0",
         "protoc-gen-openapiv2>=0.0.1",


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #13 (high severity): `cryptography` 44.0.0-49.x has a Bleichenbacher-oracle vulnerability in PKCS#7 `EnvelopedData` decryption, patched in `50.0.0`.
- The previous pin (`>=46.0.6,<49`) fell entirely inside the vulnerable range, and its upper bound actively prevented the fix from ever being installed.
- Raised the floor to `>=50.0.0` (the correct remediation for a high-severity CVE — forces every install/upgrade onto a safe version, rather than just permitting one) and removed the upper bound, since `50.0.0` is currently the latest release and there's nothing yet to bound against.

## Test plan
- [x] `pip install -e .` with `cryptography==50.0.0` — `pip check` reports no broken requirements
- [x] SDK imports cleanly
- [x] Exercised the actual crypto code paths used elsewhere in the SDK against 50.0.0: `AESGCM` round-trip, and the RSA keygen + PEM serialization path used by `get_jwks()` — both work correctly
- [x] Full test suite (297 tests) still collects without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)