### PR TITLE
docs: Align setup wording and publish the release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ At the beginning of each session, if changes to code need to be made, ask the us
 ## Commands
 
 ```bash
-make setup   # Create .venv and install the SDK
+make setup   # Create/update .venv and install dependencies
 make lint    # compileall on scalekit/ and tests/
 make test    # unittest discover
 make generate  # Regenerate from proto (needs buf)
@@ -22,6 +22,6 @@ Package: `scalekit-sdk-python` on PyPI. Workflow: `.github/workflows/release.yml
 1. Bump `scalekit/_version.py`. Use a minor or patch bump. `setup.py` reads this file.
 2. Review the unreleased changes. If proto or generated API files changed, extra generation steps apply. Those steps are not documented yet. Do not invent them. Ask before you regenerate.
 3. Merge the release branch to `main`.
-4. Create a git tag that matches the version (`v2.17.0` for `2.17.0`). Draft a GitHub Release for that tag.
-5. Publishing does not start on its own. Open the Actions run for the release workflow. Any peer can approve it. The `release` environment gates deploy.
+4. Create a git tag that matches the version (`v2.17.0` for `2.17.0`). Create and publish a GitHub Release for that tag.
+5. After publication, the Release workflow starts automatically. Open the Actions run and obtain approval for the `release` environment.
 6. After approval, the workflow publishes to PyPI.


### PR DESCRIPTION
## Summary

Addresses CodeRabbit on #193.

- `make setup` now says create/update `.venv` and install dependencies.
- A draft GitHub Release does not start the publish workflow. The steps now say to publish the release, then approve the Actions `release` environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scalekit-inc/codesmith/scalekit-sdk-python/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789712108&installation_model_id=431434&pr_number=194&repository=scalekit-inc%2Fscalekit-sdk-python&return_to=https%3A%2F%2Fgithub.com%2Fscalekit-inc%2Fscalekit-sdk-python%2Fpull%2F194&signature=3adb2bb4f5fe8b49e1c5c1a470b2c5c5b75ca7655dad4ef442a31d2641c67039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup instructions, including virtual environment creation or updates and dependency installation.
  * Updated release guidance to include publishing the release and obtaining environment approval after workflow initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->