### PR TITLE
[SK-1867] fix: add gRPC keepalive options to detect dead idle connections

### DIFF
--- a/scalekit/_version.py
+++ b/scalekit/_version.py
@@ -1,3 +1,3 @@
 # Single source of truth for the SDK version.
 # Import this in setup.py and scalekit/core.py — never hardcode the version elsewhere.
-__version__ = "2.17.0"
+__version__ = "2.18.0"

--- a/scalekit/client.py
+++ b/scalekit/client.py
@@ -69,7 +69,7 @@ class ScalekitClient:
         :type                        : ``` str ```
         :param keepalive_time_ms     : How often, in milliseconds, an idle gRPC
                                         connection is verified before reuse.
-                                        Defaults to 30000; most callers never
+                                        Defaults to 60000; most callers never
                                         need to set this.
         :type                        : ``` int ```
         :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a

--- a/scalekit/client.py
+++ b/scalekit/client.py
@@ -9,7 +9,7 @@ import hmac
 import hashlib
 import base64
 from datetime import datetime, timedelta, timezone
-from scalekit.core import CoreClient
+from scalekit.core import CoreClient, DEFAULT_KEEPALIVE_TIME_MS, DEFAULT_KEEPALIVE_TIMEOUT_MS
 from scalekit.domain import DomainClient
 from scalekit.connection import ConnectionClient
 from scalekit.m2m_client import M2MClient
@@ -50,23 +50,45 @@ webhook_signature_version = "v1"
 class ScalekitClient:
     """ Class definition for scalekit client """
 
-    def __init__(self, env_url: str, client_id: str, client_secret: str):
+    def __init__(
+        self,
+        env_url: str,
+        client_id: str,
+        client_secret: str,
+        keepalive_time_ms: int = DEFAULT_KEEPALIVE_TIME_MS,
+        keepalive_timeout_ms: int = DEFAULT_KEEPALIVE_TIMEOUT_MS,
+    ):
         """
         Initializer for Scalekit base class
 
-        :param env_url        : Environment URL
-        :type                 : ``` str ```
-        :param client_id      : Client ID
-        :type                 : ``` str ```
-        :param client_secret  : Client Secret
-        :type                 : ``` str ```
+        :param env_url               : Environment URL
+        :type                        : ``` str ```
+        :param client_id             : Client ID
+        :type                        : ``` str ```
+        :param client_secret         : Client Secret
+        :type                        : ``` str ```
+        :param keepalive_time_ms     : How often, in milliseconds, an idle gRPC
+                                        connection is verified before reuse.
+                                        Defaults to 30000; most callers never
+                                        need to set this.
+        :type                        : ``` int ```
+        :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a
+                                        keepalive response before treating an
+                                        idle connection as dead. Defaults to
+                                        10000.
+        :type                        : ``` int ```
 
         :returns:
             None
         """
         try:
             self.core_client = CoreClient(
-                env_url=env_url, client_id=client_id, client_secret=client_secret)
+                env_url=env_url,
+                client_id=client_id,
+                client_secret=client_secret,
+                keepalive_time_ms=keepalive_time_ms,
+                keepalive_timeout_ms=keepalive_timeout_ms,
+            )
             self.domain = DomainClient(self.core_client)
             self.connection = ConnectionClient(self.core_client)
             self.organization = OrganizationClient(self.core_client)

--- a/scalekit/client.py
+++ b/scalekit/client.py
@@ -70,7 +70,8 @@ class ScalekitClient:
         :param keepalive_time_ms     : How often, in milliseconds, an idle gRPC
                                         connection is verified before reuse.
                                         Defaults to 60000; most callers never
-                                        need to set this.
+                                        need to set this. Set to 0 to disable
+                                        keepalive entirely.
         :type                        : ``` int ```
         :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a
                                         keepalive response before treating an

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -19,6 +19,9 @@ TMetadata = TypeVar("TMetadata")
 TOKEN_ENDPOINT = "/oauth/token"
 JWKS_ENDPOINT = "/keys"
 
+DEFAULT_KEEPALIVE_TIME_MS = 30_000
+DEFAULT_KEEPALIVE_TIMEOUT_MS = 10_000
+
 
 class WithCall(Protocol):
     def __call__(self, request: TRequest, metadata: TMetadata) -> TResponse: ...
@@ -32,16 +35,34 @@ class CoreClient:
     api_version = "20260727"
     user_agent = f"{sdk_version} Python/{platform.python_version()} ({platform.system()}; {platform.architecture()}"
 
-    def __init__(self, env_url, client_id, client_secret):
+    def __init__(
+        self,
+        env_url,
+        client_id,
+        client_secret,
+        keepalive_time_ms: int = DEFAULT_KEEPALIVE_TIME_MS,
+        keepalive_timeout_ms: int = DEFAULT_KEEPALIVE_TIMEOUT_MS,
+    ):
         """
         Initializer for Core client
 
-        :param env_url        : Environment URL
-        :type                 : ``` str ```
-        :param client_id      : Client ID
-        :type                 : ``` str ```
-        :param client_secret  : Client Secret
-        :type                 : ``` str ```
+        :param env_url               : Environment URL
+        :type                        : ``` str ```
+        :param client_id             : Client ID
+        :type                        : ``` str ```
+        :param client_secret         : Client Secret
+        :type                        : ``` str ```
+        :param keepalive_time_ms     : How often, in milliseconds, an idle gRPC
+                                        connection is verified before reuse.
+                                        Lower this if your network path drops
+                                        idle connections faster than the
+                                        default window. Defaults to 30000.
+        :type                        : ``` int ```
+        :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a
+                                        keepalive response before treating an
+                                        idle connection as dead. Defaults to
+                                        10000.
+        :type                        : ``` int ```
         :returns
             None
         """
@@ -50,6 +71,8 @@ class CoreClient:
         self.env_url = env_url
         self.client_id = client_id
         self.client_secret = client_secret
+        self.keepalive_time_ms = keepalive_time_ms
+        self.keepalive_timeout_ms = keepalive_timeout_ms
         self.keys = {}
         self.access_token = None
         self.grpc_secure_channel = None
@@ -76,8 +99,8 @@ class CoreClient:
         # silently dropped by a network intermediary while idle isn't
         # detected until the next real call is written to it.
         channel_options = [
-            ('grpc.keepalive_time_ms', 30000),
-            ('grpc.keepalive_timeout_ms', 10000),
+            ('grpc.keepalive_time_ms', self.keepalive_time_ms),
+            ('grpc.keepalive_timeout_ms', self.keepalive_timeout_ms),
             ('grpc.keepalive_permit_without_calls', 1),
             ('grpc.http2.max_pings_without_data', 0),
         ]

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -19,7 +19,14 @@ TMetadata = TypeVar("TMetadata")
 TOKEN_ENDPOINT = "/oauth/token"
 JWKS_ENDPOINT = "/keys"
 
-DEFAULT_KEEPALIVE_TIME_MS = 30_000
+# Must clear the backend's EnforcementPolicy.MinTime (30s, scalekit's
+# cmd/grpc.go) with real margin, not just match it: grpc-core pings on this
+# exact interval for as long as the channel is open (keepalive_permit_without_calls
+# below), so a value equal to MinTime leaves zero room for jitter between the
+# client's timer and the server's strike window — one early ping is a strike,
+# three and the server GOAWAYs the connection, recreating the bug this fixes.
+# 60s matches the Java SDK's default for the same reason.
+DEFAULT_KEEPALIVE_TIME_MS = 60_000
 DEFAULT_KEEPALIVE_TIMEOUT_MS = 10_000
 
 
@@ -54,9 +61,10 @@ class CoreClient:
         :type                        : ``` str ```
         :param keepalive_time_ms     : How often, in milliseconds, an idle gRPC
                                         connection is verified before reuse.
-                                        Lower this if your network path drops
-                                        idle connections faster than the
-                                        default window. Defaults to 30000.
+                                        Must stay above the backend's keepalive
+                                        MinTime (30s) with real margin, or the
+                                        server treats this ping as abuse. Defaults
+                                        to 60000.
         :type                        : ``` int ```
         :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a
                                         keepalive response before treating an

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -70,7 +70,20 @@ class CoreClient:
             channel_credentials,
             call_credentials,
         )
-        self.grpc_secure_channel = grpc.secure_channel(self.host, composite_credentials)
+        # keepalive_permit_without_calls=1 so an idle channel is still
+        # periodically verified: without it, grpc-core only sends HTTP/2
+        # keepalive PINGs while there are active calls, so a connection
+        # silently dropped by a network intermediary while idle isn't
+        # detected until the next real call is written to it.
+        channel_options = [
+            ('grpc.keepalive_time_ms', 30000),
+            ('grpc.keepalive_timeout_ms', 10000),
+            ('grpc.keepalive_permit_without_calls', 1),
+            ('grpc.http2.max_pings_without_data', 0),
+        ]
+        self.grpc_secure_channel = grpc.secure_channel(
+            self.host, composite_credentials, options=channel_options
+        )
 
     def __authenticate_client(self):
         """

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -29,11 +29,15 @@ JWKS_ENDPOINT = "/keys"
 DEFAULT_KEEPALIVE_TIME_MS = 60_000
 DEFAULT_KEEPALIVE_TIMEOUT_MS = 10_000
 
-# The Scalekit backend's EnforcementPolicy.MinTime is 30s, so any keepalive
-# below 30s is treated as abuse and the server GOAWAYs the connection. (gRPC
-# also silently clamps sub-10s values up to 10s per grpc/proposal A8, so a
-# small value never even reaches the wire as requested.) Reject 1..29999.
-MIN_KEEPALIVE_TIME_MS = 30_000
+# The floor tracks DEFAULT_KEEPALIVE_TIME_MS for the reason spelled out above:
+# the backend's EnforcementPolicy.MinTime is 30s, and a value at exactly 30s has
+# zero jitter headroom — grpc's ping timer drifts slightly early, so an early
+# ping counts as a strike and enough strikes make the server GOAWAY. 60s gives
+# 2x margin over the 30s MinTime. Since there is no legitimate reason to go below
+# the default, the only sensible choices are 0 (disabled) or >= 60s. (gRPC also
+# silently clamps sub-10s values up to 10s per grpc/proposal A8, so a small value
+# never even reaches the wire as requested.) Reject 1..59999.
+MIN_KEEPALIVE_TIME_MS = 60_000
 
 # requests defaults to no timeout, so a black-holed connection blocks the
 # calling thread until the OS abandons the socket. Bound the connect and read
@@ -93,15 +97,17 @@ class CoreClient:
         self.env_url = env_url
         self.client_id = client_id
         self.client_secret = client_secret
-        # 0 means "disabled" and is allowed through deliberately; only 1..29999
-        # is rejected, because the Scalekit server rejects keepalive below its
-        # 30s MinTime as abusive (and gRPC silently raises sub-10s values to
-        # 10s, so a small value is never what the caller asked for anyway).
+        # 0 means "disabled" and is allowed through deliberately; only 1..59999
+        # is rejected. A value below the 60s default leaves too little margin
+        # over the Scalekit server's 30s MinTime — an early ping gets struck as
+        # abusive and the server GOAWAYs — and gRPC silently raises sub-10s
+        # values to 10s, so a small value is never what the caller asked for.
         if keepalive_time_ms and keepalive_time_ms < MIN_KEEPALIVE_TIME_MS:
             raise ValueError(
                 f"keepalive_time_ms must be 0 (disabled) or >= {MIN_KEEPALIVE_TIME_MS}; "
-                f"got {keepalive_time_ms}. The Scalekit server rejects keepalive below "
-                "its 30s MinTime as abusive, and gRPC silently raises sub-10s values to 10s."
+                f"got {keepalive_time_ms}. A value below the default leaves too little "
+                "margin over the Scalekit server's 30s MinTime (early pings are struck "
+                "as abusive), and gRPC silently raises sub-10s values to 10s."
             )
         self.keepalive_time_ms = keepalive_time_ms
         self.keepalive_timeout_ms = keepalive_timeout_ms

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -29,6 +29,13 @@ JWKS_ENDPOINT = "/keys"
 DEFAULT_KEEPALIVE_TIME_MS = 60_000
 DEFAULT_KEEPALIVE_TIMEOUT_MS = 10_000
 
+# requests defaults to no timeout, so a black-holed connection blocks the
+# calling thread until the OS abandons the socket. Bound the connect and read
+# phases separately with a (connect, read) tuple.
+DEFAULT_HTTP_CONNECT_TIMEOUT_S = 10
+DEFAULT_HTTP_READ_TIMEOUT_S = 30
+DEFAULT_HTTP_TIMEOUT = (DEFAULT_HTTP_CONNECT_TIMEOUT_S, DEFAULT_HTTP_READ_TIMEOUT_S)
+
 
 class WithCall(Protocol):
     def __call__(self, request: TRequest, metadata: TMetadata) -> TResponse: ...
@@ -148,6 +155,7 @@ class CoreClient:
             headers=self.get_headers(headers=headers),
             data=data,
             verify=True,
+            timeout=DEFAULT_HTTP_TIMEOUT,
         )
         if response.status_code != 200:
             raise ScalekitServerException.promote(response)
@@ -158,7 +166,9 @@ class CoreClient:
         if self.keys and len(self.keys) > 0:
             return
         response = requests.get(
-            self.env_url + JWKS_ENDPOINT, headers=self.get_headers()
+            self.env_url + JWKS_ENDPOINT,
+            headers=self.get_headers(),
+            timeout=DEFAULT_HTTP_TIMEOUT,
         )
         response = json.loads(response.content)
         keys = response["keys"]

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -29,6 +29,12 @@ JWKS_ENDPOINT = "/keys"
 DEFAULT_KEEPALIVE_TIME_MS = 60_000
 DEFAULT_KEEPALIVE_TIMEOUT_MS = 10_000
 
+# The Scalekit backend's EnforcementPolicy.MinTime is 30s, so any keepalive
+# below 30s is treated as abuse and the server GOAWAYs the connection. (gRPC
+# also silently clamps sub-10s values up to 10s per grpc/proposal A8, so a
+# small value never even reaches the wire as requested.) Reject 1..29999.
+MIN_KEEPALIVE_TIME_MS = 30_000
+
 # requests defaults to no timeout, so a black-holed connection blocks the
 # calling thread until the OS abandons the socket. Bound the connect and read
 # phases separately with a (connect, read) tuple.
@@ -71,7 +77,8 @@ class CoreClient:
                                         Must stay above the backend's keepalive
                                         MinTime (30s) with real margin, or the
                                         server treats this ping as abuse. Defaults
-                                        to 60000.
+                                        to 60000. Set to 0 to disable keepalive
+                                        entirely.
         :type                        : ``` int ```
         :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a
                                         keepalive response before treating an
@@ -86,6 +93,16 @@ class CoreClient:
         self.env_url = env_url
         self.client_id = client_id
         self.client_secret = client_secret
+        # 0 means "disabled" and is allowed through deliberately; only 1..29999
+        # is rejected, because the Scalekit server rejects keepalive below its
+        # 30s MinTime as abusive (and gRPC silently raises sub-10s values to
+        # 10s, so a small value is never what the caller asked for anyway).
+        if keepalive_time_ms and keepalive_time_ms < MIN_KEEPALIVE_TIME_MS:
+            raise ValueError(
+                f"keepalive_time_ms must be 0 (disabled) or >= {MIN_KEEPALIVE_TIME_MS}; "
+                f"got {keepalive_time_ms}. The Scalekit server rejects keepalive below "
+                "its 30s MinTime as abusive, and gRPC silently raises sub-10s values to 10s."
+            )
         self.keepalive_time_ms = keepalive_time_ms
         self.keepalive_timeout_ms = keepalive_timeout_ms
         self.keys = {}
@@ -108,17 +125,21 @@ class CoreClient:
             channel_credentials,
             call_credentials,
         )
-        # keepalive_permit_without_calls=1 so an idle channel is still
-        # periodically verified: without it, grpc-core only sends HTTP/2
-        # keepalive PINGs while there are active calls, so a connection
-        # silently dropped by a network intermediary while idle isn't
-        # detected until the next real call is written to it.
-        channel_options = [
-            ('grpc.keepalive_time_ms', self.keepalive_time_ms),
-            ('grpc.keepalive_timeout_ms', self.keepalive_timeout_ms),
-            ('grpc.keepalive_permit_without_calls', 1),
-            ('grpc.http2.max_pings_without_data', 0),
-        ]
+        # keepalive_time_ms == 0 disables keepalive entirely: no options are
+        # passed, so grpc-core falls back to its own defaults (no idle pings).
+        channel_options = []
+        if self.keepalive_time_ms:
+            # keepalive_permit_without_calls=1 so an idle channel is still
+            # periodically verified: without it, grpc-core only sends HTTP/2
+            # keepalive PINGs while there are active calls, so a connection
+            # silently dropped by a network intermediary while idle isn't
+            # detected until the next real call is written to it.
+            channel_options = [
+                ('grpc.keepalive_time_ms', self.keepalive_time_ms),
+                ('grpc.keepalive_timeout_ms', self.keepalive_timeout_ms),
+                ('grpc.keepalive_permit_without_calls', 1),
+                ('grpc.http2.max_pings_without_data', 0),
+            ]
         self.grpc_secure_channel = grpc.secure_channel(
             self.host, composite_credentials, options=channel_options
         )

--- a/tests/test_http_timeout.py
+++ b/tests/test_http_timeout.py
@@ -1,0 +1,59 @@
+"""
+Tests that the HTTP calls in CoreClient pass a bounded timeout.
+
+requests has no default timeout, so a black-holed connection would block the
+calling thread indefinitely. authenticate() and get_jwks() must pass a
+non-None timeout to requests.post / requests.get.
+"""
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _make_core_client():
+    """Return a CoreClient instance with __init__ bypassed (no real network calls)."""
+    from scalekit.core import CoreClient
+    client = CoreClient.__new__(CoreClient)
+    client.access_token = "test-token"
+    client.host = "example.com"
+    client.env_url = "https://example.com"
+    client.client_id = "cid"
+    client.client_secret = "csec"
+    client.keys = {}
+    client.grpc_secure_channel = None
+    return client
+
+
+class TestHttpTimeout(unittest.TestCase):
+    def setUp(self):
+        self.client = _make_core_client()
+
+    def test_authenticate_passes_timeout_to_requests_post(self):
+        """authenticate() must pass a non-None timeout to requests.post."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("scalekit.core.requests.post", return_value=mock_response) as mock_post:
+            self.client.authenticate(data={"grant_type": "client_credentials"})
+
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        self.assertIn("timeout", kwargs)
+        self.assertIsNotNone(kwargs["timeout"])
+
+    def test_get_jwks_passes_timeout_to_requests_get(self):
+        """get_jwks() must pass a non-None timeout to requests.get."""
+        mock_response = MagicMock()
+        mock_response.content = json.dumps({"keys": []}).encode("utf-8")
+
+        with patch("scalekit.core.requests.get", return_value=mock_response) as mock_get:
+            self.client.get_jwks()
+
+        mock_get.assert_called_once()
+        _, kwargs = mock_get.call_args
+        self.assertIn("timeout", kwargs)
+        self.assertIsNotNone(kwargs["timeout"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_keepalive_channel_options.py
+++ b/tests/test_keepalive_channel_options.py
@@ -67,15 +67,20 @@ class TestKeepaliveChannelOptions(unittest.TestCase):
         self.assertIn(('grpc.keepalive_time_ms', 60000), options)
 
     def test_below_minimum_raises_value_error(self):
-        """keepalive_time_ms below the 30s minimum must raise ValueError."""
+        """keepalive_time_ms below the 60s minimum must raise ValueError."""
         with self.assertRaises(ValueError):
             _build_client(keepalive_time_ms=5000)
 
-    def test_thirty_seconds_boundary_accepted(self):
-        """keepalive_time_ms=30000 is the boundary and must be accepted."""
-        _, mock_secure_channel = _build_client(keepalive_time_ms=30000)
+    def test_thirty_seconds_now_raises_value_error(self):
+        """keepalive_time_ms=30000 is below the 60s minimum and must raise ValueError."""
+        with self.assertRaises(ValueError):
+            _build_client(keepalive_time_ms=30000)
+
+    def test_sixty_seconds_boundary_accepted(self):
+        """keepalive_time_ms=60000 is the boundary and must be accepted."""
+        _, mock_secure_channel = _build_client(keepalive_time_ms=60000)
         options = self._options_from(mock_secure_channel)
-        self.assertIn(('grpc.keepalive_time_ms', 30000), options)
+        self.assertIn(('grpc.keepalive_time_ms', 60000), options)
 
 
 if __name__ == "__main__":

--- a/tests/test_keepalive_channel_options.py
+++ b/tests/test_keepalive_channel_options.py
@@ -1,0 +1,82 @@
+"""
+Tests for gRPC keepalive channel options in CoreClient.
+
+Covers the runtime escape hatch (keepalive_time_ms=0 disables keepalive) and
+the sub-10s validation guard (gRPC clamps values below 10s up to 10s, which
+the Scalekit server rejects).
+
+These tests never touch the network: __authenticate_client is mocked and
+grpc.secure_channel is mocked, so only the channel-option wiring is exercised.
+"""
+import unittest
+from unittest.mock import patch
+
+from scalekit.core import (
+    CoreClient,
+    DEFAULT_KEEPALIVE_TIME_MS,
+    DEFAULT_KEEPALIVE_TIMEOUT_MS,
+)
+
+
+def _build_client(**kwargs):
+    """Construct a CoreClient with auth and channel creation stubbed.
+
+    Returns (client, mock_secure_channel) so tests can assert on the options
+    passed to grpc.secure_channel.
+    """
+    with patch.object(CoreClient, "_CoreClient__authenticate_client"), \
+            patch("scalekit.core.grpc.secure_channel") as mock_secure_channel, \
+            patch("scalekit.core.grpc.ssl_channel_credentials"), \
+            patch("scalekit.core.grpc.access_token_call_credentials"), \
+            patch("scalekit.core.grpc.composite_channel_credentials"):
+        client = CoreClient(
+            env_url="https://example.com",
+            client_id="cid",
+            client_secret="csec",
+            **kwargs,
+        )
+    return client, mock_secure_channel
+
+
+class TestKeepaliveChannelOptions(unittest.TestCase):
+    def _options_from(self, mock_secure_channel):
+        """Extract the options kwarg from the secure_channel call."""
+        mock_secure_channel.assert_called_once()
+        _, kwargs = mock_secure_channel.call_args
+        return kwargs["options"]
+
+    def test_disabled_passes_empty_options(self):
+        """keepalive_time_ms=0 must call secure_channel with options=[]."""
+        _, mock_secure_channel = _build_client(keepalive_time_ms=0)
+        self.assertEqual(self._options_from(mock_secure_channel), [])
+
+    def test_default_construction_includes_all_four_options(self):
+        """Default construction must include all four expected option tuples."""
+        _, mock_secure_channel = _build_client()
+        options = self._options_from(mock_secure_channel)
+        self.assertEqual(
+            options,
+            [
+                ('grpc.keepalive_time_ms', DEFAULT_KEEPALIVE_TIME_MS),
+                ('grpc.keepalive_timeout_ms', DEFAULT_KEEPALIVE_TIMEOUT_MS),
+                ('grpc.keepalive_permit_without_calls', 1),
+                ('grpc.http2.max_pings_without_data', 0),
+            ],
+        )
+        # Explicit check on the documented default value.
+        self.assertIn(('grpc.keepalive_time_ms', 60000), options)
+
+    def test_below_minimum_raises_value_error(self):
+        """keepalive_time_ms below the 30s minimum must raise ValueError."""
+        with self.assertRaises(ValueError):
+            _build_client(keepalive_time_ms=5000)
+
+    def test_thirty_seconds_boundary_accepted(self):
+        """keepalive_time_ms=30000 is the boundary and must be accepted."""
+        _, mock_secure_channel = _build_client(keepalive_time_ms=30000)
+        options = self._options_from(mock_secure_channel)
+        self.assertIn(('grpc.keepalive_time_ms', 30000), options)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`scalekit/core.py`'s `__grpc_secure_channel` calls `grpc.secure_channel(self.host, composite_credentials)` with no `options` at all. grpc-core's default `keepalive_permit_without_calls` is `0` (false), which means **keepalive pings are skipped entirely whenever the channel has zero active RPCs**. An idle channel therefore has no liveness detection at all — if a network intermediary (LB, NAT, proxy) silently drops the connection while it's idle, the client has no way to know until the next real call writes into the dead socket, which then fails with a raw transport error instead of a clean reconnect.

## Fix

Added channel options in `core.py`:
```python
channel_options = [
    ('grpc.keepalive_time_ms', 60000),
    ('grpc.keepalive_timeout_ms', 10000),
    ('grpc.keepalive_permit_without_calls', 1),
    ('grpc.http2.max_pings_without_data', 0),
]
```

`keepalive_time_ms` / `keepalive_timeout_ms` are exposed as constructor kwargs on both `CoreClient` and `ScalekitClient`.

## Escape hatch + input validation

Two follow-up gaps closed on top of the base fix:

- **Runtime escape hatch.** `keepalive_time_ms=0` now disables keepalive entirely — no channel options are passed, so grpc-core falls back to its own defaults (no idle pings). A customer whose network path or proxy rejects the pings (GOAWAY / ENHANCE_YOUR_CALM / too_many_pings) can turn keepalive off at runtime instead of downgrading the SDK.
- **Reject values below the 60s default.** `keepalive_time_ms` in `1..59999` now raises `ValueError` in the constructor. The floor tracks the 60s default: the Scalekit server's `EnforcementPolicy.MinTime` is 30s, and a value at exactly 30s has zero jitter headroom — grpc's ping timer drifts slightly early, so an early ping is struck as abusive and enough strikes make the server GOAWAY. 60s gives 2x margin. Since there is no legitimate reason to configure below the default, the only sensible choices are `0` (disabled) or `>= 60000`. gRPC also silently clamps sub-10s values up to 10s (grpc/proposal A8), so a caller passing `5000` expecting 5s would otherwise silently get the most aggressive setting available. `0` passes validation deliberately (it means "disabled", not "invalid").

## ⚠️ Blocked on backend coordination — do not merge/release yet

`keepalive_permit_without_calls: 1` makes the channel send keepalive PINGs even with **no active call** (idle). Whether that's safe depends on the server's own gRPC keepalive enforcement policy allowing pings with no active stream — if the server currently rejects those, it would treat this SDK's own idle-liveness pings as abuse and close the connection, recreating the same failure via a different trigger. Needs sign-off from whoever owns the server-side gRPC keepalive config before this merges/releases.

## Also in this PR — HTTP timeouts on token & JWKS calls

The two `requests` calls in `core.py` (`authenticate()`'s token POST and `get_jwks()`'s JWKS GET) passed no `timeout`, so `requests` used its default of **no timeout** — a black-holed connection blocked the calling thread until the OS abandoned the socket, effectively forever. Because `__authenticate_client()` runs on startup and on the `UNAUTHENTICATED` gRPC-refresh path, an unbounded token POST could hang application startup and hang gRPC calls that trigger a token refresh — on a socket no gRPC channel setting can reach. Fixed by adding a module-level `DEFAULT_HTTP_TIMEOUT = (connect, read) = (10s, 30s)` tuple and passing it at both call sites.

## Verification

- Syntax/import check clean.
- Full test suite run before/after this change against a live staging environment: identical pass/fail split (pre-existing failures from missing test fixtures in that env, confirmed via `git stash` isolation — unrelated to this change, unchanged with or without it).
- Empirical idle-reuse reproduction against staging (idle gaps up to 11 min): both baseline and this fix succeeded with zero failures — that network path tolerates longer idle windows than tested, so the exact failure mode couldn't be triggered empirically. Confirms no regression; root cause is established via source-level inspection of grpc-core's keepalive semantics, not empirical reproduction.
- New offline unit tests (`tests/test_keepalive_channel_options.py`) mock `grpc.secure_channel` and assert on the `options` kwarg: `keepalive_time_ms=0` → `options=[]`; default → all four option tuples incl. `('grpc.keepalive_time_ms', 60000)`; `5000` and `30000` → `ValueError`; `60000` boundary → accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable connection keepalive intervals and timeouts.
  * Connections can remain active during periods without calls, improving long-lived connection reliability.
  * Existing integrations continue using sensible default keepalive settings.
  * Updated the SDK to version 2.18.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
