### PR TITLE
Add list_tools method to actions facade with ListToolsResponse

### DIFF
--- a/scalekit/actions/actions.py
+++ b/scalekit/actions/actions.py
@@ -198,7 +198,7 @@ class ActionClient:
         :param identifier: Filter/resolve by connected-account identifier (optional)
         :type: str
         :param provider: Filter by provider key, e.g. 'github' (optional)
-        :type: List[str]
+        :type: str
         :param tool_name: Filter to specific tool names (optional)
         :type: List[str]
         :param query: Free-form search query across tool metadata (optional)

--- a/scalekit/actions/actions.py
+++ b/scalekit/actions/actions.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Optional, Any, List, Dict, Union
 import requests
-from scalekit.actions.types import ToolRequest,ExecuteToolResponse,MagicLinkResponse,ListConnectedAccountsResponse,DeleteConnectedAccountResponse,GetConnectedAccountAuthResponse,GetConnectedAccountDetailsResponse,ToolInput, \
+from scalekit.actions.types import ToolRequest,ExecuteToolResponse,MagicLinkResponse,ListConnectedAccountsResponse,ListToolsResponse,DeleteConnectedAccountResponse,GetConnectedAccountAuthResponse,GetConnectedAccountDetailsResponse,ToolInput, \
     UpdateConnectedAccountResponse,CreateMcpConfigResponse,ListMcpConfigsResponse,UpdateMcpConfigResponse,DeleteMcpConfigResponse, \
     EnsureMcpInstanceResponse,UpdateMcpInstanceResponse,GetMcpInstanceResponse,ListMcpInstancesResponse,DeleteMcpInstanceResponse,GetMcpInstanceAuthStateResponse, \
     McpConfig,McpConfigConnectionToolMapping,VerifyConnectedAccountUserResponse, \
@@ -16,6 +16,8 @@ from scalekit.actions.modifier import (
     apply_pre_modifiers, apply_post_modifiers
 )
 from scalekit.common.exceptions import ScalekitNotFoundException
+from scalekit.v1.tools.tools_pb2 import Filter
+from google.protobuf.wrappers_pb2 import BoolValue
 
 
 
@@ -168,9 +170,86 @@ class ActionClient:
         modified_response = apply_post_modifiers(tool_name, response.data, self._modifiers)
 
         response.data = modified_response
-        
+
         return response
-    
+
+    def list_tools(
+        self,
+        connection_name: Optional[str] = None,
+        identifier: Optional[str] = None,
+        provider: Optional[str] = None,
+        tool_name: Optional[List[str]] = None,
+        query: Optional[str] = None,
+        organization_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        connected_account_id: Optional[str] = None,
+        summary: Optional[bool] = None,
+        page_size: Optional[int] = None,
+        page_token: Optional[str] = None,
+        **kwargs
+    ) -> ListToolsResponse:
+        """
+        List tools available in your workspace, optionally scoped to a connected account.
+
+        Thin wrapper around ToolsClient.list_tools.
+
+        :param connection_name: Filter by connector identifier, e.g. 'github-connect' (optional)
+        :type: str
+        :param identifier: Filter/resolve by connected-account identifier (optional)
+        :type: str
+        :param provider: Filter by provider key, e.g. 'github' (optional)
+        :type: List[str]
+        :param tool_name: Filter to specific tool names (optional)
+        :type: List[str]
+        :param query: Free-form search query across tool metadata (optional)
+        :type: str
+        :param organization_id: Organization ID to scope the connected-account lookup (optional)
+        :type: str
+        :param user_id: User ID to scope the connected-account lookup (optional)
+        :type: str
+        :param connected_account_id: Direct connected account ID, as an alternative to
+            identifier + connection_name (optional)
+        :type: str
+        :param summary: Whether to return a summarized tool definition (optional)
+        :type: bool
+        :param page_size: Maximum number of tools to return per page (optional)
+        :type: int
+        :param page_token: Token from a previous response for pagination (optional)
+        :type: str
+
+        :returns:
+            ListToolsResponse containing the matching tools
+        """
+        has_filter_fields = any([
+            connection_name, identifier, provider, tool_name,
+            query, organization_id, user_id, connected_account_id,
+            summary is not None,
+        ])
+        filter_kwargs = {
+            "connector": connection_name,
+            "identifier": identifier,
+            "provider": provider,
+            "tool_name": tool_name,
+            "query": query,
+            "organization_id": organization_id,
+            "user_id": user_id,
+            "connected_account_id": connected_account_id,
+        }
+        if summary is not None:
+            filter_kwargs["summary"] = BoolValue(value=summary)
+        filter_obj = Filter(**filter_kwargs) if has_filter_fields else None
+
+        # Call the existing tools.list_tools which returns (response, metadata) tuple
+        result_tuple = self.tools.list_tools(
+            filter=filter_obj,
+            page_size=page_size,
+            page_token=page_token
+        )
+
+        proto_response = result_tuple[0]
+
+        return ListToolsResponse.from_proto(proto_response)
+
     def get_authorization_link(
             self,
             identifier: Optional[str] = None,

--- a/scalekit/actions/models/responses/list_tools_response.py
+++ b/scalekit/actions/models/responses/list_tools_response.py
@@ -48,15 +48,15 @@ class Tool(BaseModel):
             Tool instance
         """
         definition = None
-        if proto_tool.definition:
+        if proto_tool.HasField("definition"):
             definition = MessageToDict(proto_tool.definition)
 
         metadata = None
-        if proto_tool.metadata:
+        if proto_tool.HasField("metadata"):
             metadata = MessageToDict(proto_tool.metadata)
 
         updated_at = None
-        if proto_tool.updated_at:
+        if proto_tool.HasField("updated_at"):
             updated_at = proto_tool.updated_at.ToDatetime()
 
         return cls(

--- a/scalekit/actions/models/responses/list_tools_response.py
+++ b/scalekit/actions/models/responses/list_tools_response.py
@@ -1,0 +1,165 @@
+from typing import List, Optional
+from datetime import datetime
+from pydantic import BaseModel, Field
+from google.protobuf.json_format import MessageToDict
+
+
+class Tool(BaseModel):
+    """Tool item in list response with one-to-one mapping to proto Tool"""
+
+    id: Optional[str] = Field(
+        None,
+        description="Unique identifier for the tool"
+    )
+    provider: Optional[str] = Field(
+        None,
+        description="Provider that exposes this tool (e.g., 'github', 'slack')"
+    )
+    definition: Optional[dict] = Field(
+        None,
+        description="Tool definition (schema/parameters) as a dictionary"
+    )
+    metadata: Optional[dict] = Field(
+        None,
+        description="Additional metadata for the tool"
+    )
+    tags: List[str] = Field(
+        default_factory=list,
+        description="Tags associated with the tool"
+    )
+    is_default: Optional[bool] = Field(
+        None,
+        description="Whether this is a default tool for its provider"
+    )
+    updated_at: Optional[datetime] = Field(
+        None,
+        description="Timestamp when the tool was last updated"
+    )
+
+    @classmethod
+    def from_proto(cls, proto_tool) -> 'Tool':
+        """
+        Create Tool from protobuf Tool
+
+        :param proto_tool: The protobuf Tool object
+        :type proto_tool: Tool (from tools_pb2)
+
+        :returns:
+            Tool instance
+        """
+        definition = None
+        if proto_tool.definition:
+            definition = MessageToDict(proto_tool.definition)
+
+        metadata = None
+        if proto_tool.metadata:
+            metadata = MessageToDict(proto_tool.metadata)
+
+        updated_at = None
+        if proto_tool.updated_at:
+            updated_at = proto_tool.updated_at.ToDatetime()
+
+        return cls(
+            id=proto_tool.id if proto_tool.id else None,
+            provider=proto_tool.provider if proto_tool.provider else None,
+            definition=definition,
+            metadata=metadata,
+            tags=list(proto_tool.tags),
+            is_default=proto_tool.is_default.value if proto_tool.HasField("is_default") else None,
+            updated_at=updated_at
+        )
+
+    def to_dict(self) -> dict:
+        """
+        Convert to dictionary representation
+
+        :returns:
+            Dictionary representation of the tool
+        """
+        return {
+            "id": self.id,
+            "provider": self.provider,
+            "definition": self.definition,
+            "metadata": self.metadata,
+            "tags": self.tags,
+            "is_default": self.is_default,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None
+        }
+
+    class Config:
+        """Pydantic configuration"""
+        validate_assignment = True
+        json_encoders = {
+            datetime: lambda v: v.isoformat() if v else None
+        }
+
+
+class ListToolsResponse(BaseModel):
+    """List tools response with one-to-one mapping to proto ListToolsResponse"""
+
+    tools: List[Tool] = Field(
+        default_factory=list,
+        description="List of tools"
+    )
+    tool_names: List[str] = Field(
+        default_factory=list,
+        description="Names of the tools in this page"
+    )
+    total_count: Optional[int] = Field(
+        None,
+        description="Total number of tools matching the request",
+        alias="total_size"
+    )
+    next_page_token: Optional[str] = Field(
+        None,
+        description="Token for the next page of results"
+    )
+    previous_page_token: Optional[str] = Field(
+        None,
+        description="Token for the previous page of results",
+        alias="prev_page_token"
+    )
+
+    @classmethod
+    def from_proto(cls, proto_response) -> 'ListToolsResponse':
+        """
+        Create ListToolsResponse from protobuf ListToolsResponse
+
+        :param proto_response: The protobuf ListToolsResponse object
+        :type proto_response: ListToolsResponse (from tools_pb2)
+
+        :returns:
+            ListToolsResponse instance
+        """
+        tools = [Tool.from_proto(proto_tool) for proto_tool in proto_response.tools]
+
+        return cls(
+            tools=tools,
+            tool_names=list(proto_response.tool_names),
+            total_count=proto_response.total_size if proto_response.total_size else None,
+            next_page_token=proto_response.next_page_token if proto_response.next_page_token else None,
+            previous_page_token=proto_response.prev_page_token if proto_response.prev_page_token else None
+        )
+
+    def to_dict(self) -> dict:
+        """
+        Convert to dictionary representation
+
+        :returns:
+            Dictionary representation of the response
+        """
+        return {
+            "tools": [tool.to_dict() for tool in self.tools],
+            "tool_names": self.tool_names,
+            "total_count": self.total_count,
+            "next_page_token": self.next_page_token,
+            "previous_page_token": self.previous_page_token
+        }
+
+    class Config:
+        """Pydantic configuration"""
+        validate_assignment = True
+        populate_by_name = True
+        json_encoders = {
+            datetime: lambda v: v.isoformat() if v else None
+        }

--- a/scalekit/actions/models/responses/list_tools_response.py
+++ b/scalekit/actions/models/responses/list_tools_response.py
@@ -136,7 +136,7 @@ class ListToolsResponse(BaseModel):
         return cls(
             tools=tools,
             tool_names=list(proto_response.tool_names),
-            total_count=proto_response.total_size if proto_response.total_size else None,
+            total_count=proto_response.total_size,
             next_page_token=proto_response.next_page_token if proto_response.next_page_token else None,
             previous_page_token=proto_response.prev_page_token if proto_response.prev_page_token else None
         )

--- a/scalekit/actions/types.py
+++ b/scalekit/actions/types.py
@@ -5,6 +5,7 @@ from .models.requests.update_connected_account_request import UpdateConnectedAcc
 from .models.responses.execute_tool_response import ExecuteToolResponse
 from .models.responses.magic_link_response import MagicLinkResponse
 from .models.responses.list_connected_accounts_response import ListConnectedAccountsResponse
+from .models.responses.list_tools_response import Tool, ListToolsResponse
 from .models.responses.delete_connected_account_response import DeleteConnectedAccountResponse
 from .models.responses.get_connected_account_auth_response import GetConnectedAccountAuthResponse, GetConnectedAccountDetailsResponse
 from .models.responses.create_connected_account_response import CreateConnectedAccountResponse
@@ -48,6 +49,8 @@ __all__ = [
     'ExecuteToolResponse',
     'MagicLinkResponse',
     'ListConnectedAccountsResponse',
+    'Tool',
+    'ListToolsResponse',
     'DeleteConnectedAccountResponse',
     'GetConnectedAccountAuthResponse',
     'GetConnectedAccountDetailsResponse',

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -7,6 +7,7 @@ from scalekit.actions.types import (
     ExecuteToolResponse,
     MagicLinkResponse,
     ListConnectedAccountsResponse,
+    ListToolsResponse,
     DeleteConnectedAccountResponse,
     GetConnectedAccountAuthResponse,
     GetConnectedAccountDetailsResponse,
@@ -170,6 +171,37 @@ class TestConnect(BaseTest):
         )
         self.assertIsNotNone(result)
         self.assertIsInstance(result, ListConnectedAccountsResponse)
+
+    def test_list_tools_method_exists(self):
+        """Method to test list_tools method exists on the actions facade"""
+        self.assertTrue(hasattr(self.scalekit_client.actions, 'list_tools'))
+        self.assertTrue(callable(self.scalekit_client.actions.list_tools))
+
+    def test_list_tools_response_structure(self):
+        """Method to test list_tools returns ListToolsResponse"""
+        result = self.scalekit_client.actions.list_tools()
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, ListToolsResponse)
+        self.assertTrue(hasattr(result, 'tools'))
+        self.assertTrue(hasattr(result, 'tool_names'))
+        self.assertTrue(hasattr(result, 'total_count'))
+        self.assertTrue(hasattr(result, 'next_page_token'))
+        self.assertTrue(hasattr(result, 'previous_page_token'))
+
+    def test_list_tools_with_connection_name_and_identifier(self):
+        """connection_name + identifier filter passes through to the tools client and returns a valid response."""
+        result = self.scalekit_client.actions.list_tools(
+            connection_name=self.test_connection_name,
+            identifier=self.test_identifier,
+        )
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, ListToolsResponse)
+
+    def test_list_tools_with_page_size(self):
+        """list_tools supports pagination parameters."""
+        result = self.scalekit_client.actions.list_tools(page_size=5)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, ListToolsResponse)
 
     def test_magic_link_response_structure(self):
         """Method to test MagicLinkResponse structure and methods"""


### PR DESCRIPTION
## Summary
Add support for listing tools available in a workspace through the actions facade, with optional filtering by connected account, provider, and other criteria.

## Key Changes
- **New response model**: Created `ListToolsResponse` and `Tool` classes in `scalekit/actions/models/responses/list_tools_response.py` with:
  - Protobuf conversion via `from_proto()` class method
  - Dictionary serialization via `to_dict()` method
  - Proper handling of nested protobuf messages and timestamp conversion
  - Support for field aliases (`total_size` → `total_count`, `prev_page_token` → `previous_page_token`)

- **New facade method**: Added `list_tools()` method to `ActionsClient` in `scalekit/actions/actions.py` that:
  - Accepts optional filters: `connection_name`, `identifier`, `provider`, `tool_name`, `query`, `organization_id`, `user_id`, `connected_account_id`
  - Supports pagination via `page_size` and `page_token`
  - Supports `summary` parameter for summarized tool definitions
  - Wraps the underlying `tools.list_tools()` gRPC client call
  - Returns a `ListToolsResponse` instance

- **Type exports**: Updated `scalekit/actions/types.py` to export `Tool` and `ListToolsResponse`

- **Tests**: Added comprehensive test coverage in `tests/test_actions.py`:
  - Verify method exists and is callable
  - Validate response structure and attributes
  - Test filtering with `connection_name` and `identifier`
  - Test pagination with `page_size`

## Implementation Details
- The `list_tools()` method conditionally builds a `Filter` protobuf object only when filter fields are provided
- Handles optional `BoolValue` wrapping for the `summary` parameter
- Converts protobuf `Timestamp` to Python `datetime` objects
- Properly handles optional fields with `None` defaults

https://claude.ai/code/session_016LeBPGDAHe314sL2Pxbz3f

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scalekit-inc/codesmith/scalekit-sdk-python/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791554315&installation_model_id=431434&pr_number=201&repository=scalekit-inc%2Fscalekit-sdk-python&return_to=https%3A%2F%2Fgithub.com%2Fscalekit-inc%2Fscalekit-sdk-python%2Fpull%2F201&signature=3da908f88df38b9bbb538e61e62265b8bba51e6579a32fcbd187fcbbb8b6de3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to list available tools through the Actions interface.
  - Supports filtering by connection, identifier, provider, tool name, query, account, and ownership details.
  - Added pagination for browsing large tool collections, including next- and previous-page navigation.
  - Tool listings include names, metadata, definitions, tags, default status, update timestamps, and total result counts.
  - Added structured response data for easier access to tool details and pagination information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->