### PR TITLE
[SK-1867] fix: add client-side idle-connection timeout (grpc.client_idle_timeout_ms)

### DIFF
--- a/scalekit/_version.py
+++ b/scalekit/_version.py
@@ -1,3 +1,3 @@
 # Single source of truth for the SDK version.
 # Import this in setup.py and scalekit/core.py — never hardcode the version elsewhere.
-__version__ = "2.19.0"
+__version__ = "2.20.0"

--- a/scalekit/_version.py
+++ b/scalekit/_version.py
@@ -1,3 +1,3 @@
 # Single source of truth for the SDK version.
 # Import this in setup.py and scalekit/core.py — never hardcode the version elsewhere.
-__version__ = "2.20.0"
+__version__ = "2.19.1"

--- a/scalekit/client.py
+++ b/scalekit/client.py
@@ -78,9 +78,14 @@ class ScalekitClient:
         :type                        : ``` str ```
         :param keepalive_time_ms     : How often, in milliseconds, an idle gRPC
                                         connection is verified before reuse.
+                                        Also derives grpc.client_idle_timeout_ms
+                                        (see CLIENT_IDLE_TIMEOUT_CEILING_MS),
+                                        which proactively recycles a connection
+                                        with zero active calls before the
+                                        backend's own MaxConnectionIdle would.
                                         Defaults to 60000; most callers never
                                         need to set this. Set to 0 to disable
-                                        keepalive entirely.
+                                        both entirely.
         :type                        : ``` int ```
         :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a
                                         keepalive response before treating an

--- a/scalekit/client.py
+++ b/scalekit/client.py
@@ -85,7 +85,12 @@ class ScalekitClient:
                                         backend's own MaxConnectionIdle would.
                                         Defaults to 60000; most callers never
                                         need to set this. Set to 0 to disable
-                                        both entirely.
+                                        both of this SDK's own settings for
+                                        these — grpc-core still applies its own
+                                        (much larger) default idle behavior
+                                        when no options are passed at all, so
+                                        this isn't "no idle handling," just no
+                                        SDK-configured one.
         :type                        : ``` int ```
         :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a
                                         keepalive response before treating an

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -45,6 +45,32 @@ DEFAULT_KEEPALIVE_TIMEOUT_MS = 10_000
 # never even reaches the wire as requested.) Reject 1..59999.
 MIN_KEEPALIVE_TIME_MS = 60_000
 
+# grpc-core exposes 'grpc.client_idle_timeout_ms' (gRFC A9) as the client-side
+# equivalent of what the Go and Node SDKs implement by hand on their
+# self-managed HTTP/2 transports (grpcIdleConnTimeout / idleConnectionTimeoutMs):
+# proactively transition a fully-idle channel so its connection is torn down
+# and lazily recreated on the next call, instead of waiting to discover it's
+# dead (or waiting for the backend to GOAWAY it) only when a real request is
+# written to it. This SDK previously configured keepalive pings but never this
+# option — the gap this constant and CLIENT_IDLE_TIMEOUT_PING_CYCLES close.
+#
+# Must stay strictly BELOW the backend's own grpcKeepaliveMaxConnectionIdle
+# (5 min, scalekit's cmd/grpc.go), not equal to it: landing exactly on the
+# backend's bound is a race — whichever side's timer fires first wins, and the
+# loser is a request written into a socket the other side just closed. Mirrors
+# the Go SDK's grpcIdleConnCeiling and the Node SDK's
+# IDLE_CONNECTION_TIMEOUT_CEILING_MS exactly (both 4 minutes), for the same
+# reason.
+CLIENT_IDLE_TIMEOUT_CEILING_MS = 240_000
+
+# Multiplier applied to keepalive_time_ms before clamping to the ceiling above
+# — mirrors the Go SDK's grpcIdleConnPingCycles / Node SDK's
+# IDLE_PING_CYCLES_BEFORE_CLOSE (both 5) exactly, so this SDK scales down
+# correctly alongside the other two should MIN_KEEPALIVE_TIME_MS itself ever
+# be lowered. Superseded by the ceiling for every currently-valid non-zero
+# keepalive_time_ms (60s x 5 = 300s already exceeds the 4-minute ceiling).
+CLIENT_IDLE_TIMEOUT_PING_CYCLES = 5
+
 # requests defaults to no timeout, so a black-holed connection blocks the
 # calling thread until the OS abandons the socket. Bound the connect and read
 # phases separately with a (connect, read) tuple.
@@ -111,6 +137,22 @@ def _assert_valid_timeout(name: str, value) -> None:
         raise ValueError(
             f"{name} must be a positive, finite number of seconds; got {value!r}."
         )
+
+
+def _client_idle_timeout_ms_for(keepalive_time_ms: int) -> int:
+    """Derive grpc.client_idle_timeout_ms from keepalive_time_ms — mirrors the
+    Go SDK's idleConnTimeoutFor / Node SDK's idleConnectionTimeoutMsFor exactly
+    (same formula, same constants), so the three SDKs land on the same idle-close
+    behavior. keepalive_time_ms == 0 (disabled) returns 0, meaning "not set" to
+    the caller (see __grpc_secure_channel — no option is passed, so grpc-core's
+    own much larger default applies), consistent with keepalive_time_ms == 0
+    disabling the ping-based idle detection above too."""
+    if not keepalive_time_ms:
+        return 0
+    scaled = keepalive_time_ms * CLIENT_IDLE_TIMEOUT_PING_CYCLES
+    if scaled <= 0 or scaled > CLIENT_IDLE_TIMEOUT_CEILING_MS:
+        return CLIENT_IDLE_TIMEOUT_CEILING_MS
+    return scaled
 
 
 def _is_success_status(status_code: int) -> bool:
@@ -242,8 +284,10 @@ class CoreClient:
             channel_credentials,
             call_credentials,
         )
-        # keepalive_time_ms == 0 disables keepalive entirely: no options are
-        # passed, so grpc-core falls back to its own defaults (no idle pings).
+        # keepalive_time_ms == 0 disables keepalive (and, below, the derived
+        # idle-close timeout) entirely: no options are passed, so grpc-core
+        # falls back to its own defaults (no idle pings, ~30 min idle timeout)
+        # — an escape hatch for a network path that rejects this pattern.
         channel_options = []
         if self.keepalive_time_ms:
             # keepalive_permit_without_calls=1 so an idle channel is still
@@ -256,6 +300,10 @@ class CoreClient:
                 ('grpc.keepalive_timeout_ms', self.keepalive_timeout_ms),
                 ('grpc.keepalive_permit_without_calls', 1),
                 ('grpc.http2.max_pings_without_data', 0),
+                # Proactively idle out (and lazily recreate on next use) a
+                # connection with zero active calls before the backend's own
+                # MaxConnectionIdle would — see CLIENT_IDLE_TIMEOUT_CEILING_MS.
+                ('grpc.client_idle_timeout_ms', _client_idle_timeout_ms_for(self.keepalive_time_ms)),
             ]
         self.grpc_secure_channel = grpc.secure_channel(
             self.host, composite_credentials, options=channel_options

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -219,7 +219,12 @@ class CoreClient:
                                         proactively recycles a connection with
                                         zero active calls before the backend's
                                         own MaxConnectionIdle would. Defaults to
-                                        60000. Set to 0 to disable both entirely.
+                                        60000. Set to 0 to disable both of this
+                                        SDK's own settings for these — grpc-core
+                                        still applies its own (much larger)
+                                        default idle behavior when no options
+                                        are passed at all, so this isn't "no
+                                        idle handling," just no SDK-configured one.
         :type                        : ``` int ```
         :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a
                                         keepalive response before treating an

--- a/scalekit/core.py
+++ b/scalekit/core.py
@@ -213,9 +213,13 @@ class CoreClient:
                                         connection is verified before reuse.
                                         Must stay above the backend's keepalive
                                         MinTime (30s) with real margin, or the
-                                        server treats this ping as abuse. Defaults
-                                        to 60000. Set to 0 to disable keepalive
-                                        entirely.
+                                        server treats this ping as abuse. Also
+                                        derives grpc.client_idle_timeout_ms (see
+                                        CLIENT_IDLE_TIMEOUT_CEILING_MS), which
+                                        proactively recycles a connection with
+                                        zero active calls before the backend's
+                                        own MaxConnectionIdle would. Defaults to
+                                        60000. Set to 0 to disable both entirely.
         :type                        : ``` int ```
         :param keepalive_timeout_ms  : How long, in milliseconds, to wait for a
                                         keepalive response before treating an

--- a/tests/test_keepalive_channel_options.py
+++ b/tests/test_keepalive_channel_options.py
@@ -15,6 +15,9 @@ from scalekit.core import (
     CoreClient,
     DEFAULT_KEEPALIVE_TIME_MS,
     DEFAULT_KEEPALIVE_TIMEOUT_MS,
+    CLIENT_IDLE_TIMEOUT_CEILING_MS,
+    CLIENT_IDLE_TIMEOUT_PING_CYCLES,
+    _client_idle_timeout_ms_for,
 )
 
 
@@ -50,8 +53,8 @@ class TestKeepaliveChannelOptions(unittest.TestCase):
         _, mock_secure_channel = _build_client(keepalive_time_ms=0)
         self.assertEqual(self._options_from(mock_secure_channel), [])
 
-    def test_default_construction_includes_all_four_options(self):
-        """Default construction must include all four expected option tuples."""
+    def test_default_construction_includes_all_five_options(self):
+        """Default construction must include all five expected option tuples."""
         _, mock_secure_channel = _build_client()
         options = self._options_from(mock_secure_channel)
         self.assertEqual(
@@ -61,10 +64,12 @@ class TestKeepaliveChannelOptions(unittest.TestCase):
                 ('grpc.keepalive_timeout_ms', DEFAULT_KEEPALIVE_TIMEOUT_MS),
                 ('grpc.keepalive_permit_without_calls', 1),
                 ('grpc.http2.max_pings_without_data', 0),
+                ('grpc.client_idle_timeout_ms', CLIENT_IDLE_TIMEOUT_CEILING_MS),
             ],
         )
-        # Explicit check on the documented default value.
+        # Explicit check on the documented default values.
         self.assertIn(('grpc.keepalive_time_ms', 60000), options)
+        self.assertIn(('grpc.client_idle_timeout_ms', 240000), options)
 
     def test_below_minimum_raises_value_error(self):
         """keepalive_time_ms below the 60s minimum must raise ValueError."""
@@ -81,6 +86,55 @@ class TestKeepaliveChannelOptions(unittest.TestCase):
         _, mock_secure_channel = _build_client(keepalive_time_ms=60000)
         options = self._options_from(mock_secure_channel)
         self.assertIn(('grpc.keepalive_time_ms', 60000), options)
+
+
+class TestClientIdleTimeout(unittest.TestCase):
+    """Regression tests for the grpc.client_idle_timeout_ms option — the
+    client-side idle-close equivalent of the Go SDK's grpcIdleConnTimeout /
+    Node SDK's idleConnectionTimeoutMs, which this SDK previously omitted."""
+
+    # The backend's own grpc.max_connection_idle enforcement (scalekit's
+    # cmd/grpc.go, grpcKeepaliveMaxConnectionIdle) — kept here as a literal,
+    # not imported, so this test independently pins the actual production
+    # value rather than trusting whatever CLIENT_IDLE_TIMEOUT_CEILING_MS
+    # happens to be set to.
+    _BACKEND_MAX_CONNECTION_IDLE_MS = 5 * 60 * 1000
+
+    def test_ceiling_is_strictly_below_backend_max_connection_idle(self):
+        """Landing exactly on (or above) the backend's own bound is a race —
+        whichever side's timer fires first wins, and the loser is a request
+        written into a socket the other side just closed."""
+        self.assertLess(CLIENT_IDLE_TIMEOUT_CEILING_MS, self._BACKEND_MAX_CONNECTION_IDLE_MS)
+
+    def test_derived_value_scales_with_keepalive_time_when_below_ceiling(self):
+        small = 1000  # hypothetically below the real MIN_KEEPALIVE_TIME_MS floor, to exercise scaling
+        self.assertEqual(
+            _client_idle_timeout_ms_for(small),
+            small * CLIENT_IDLE_TIMEOUT_PING_CYCLES,
+        )
+
+    def test_derived_value_clamps_to_ceiling_at_default_keepalive(self):
+        self.assertEqual(
+            _client_idle_timeout_ms_for(DEFAULT_KEEPALIVE_TIME_MS),
+            CLIENT_IDLE_TIMEOUT_CEILING_MS,
+        )
+
+    def test_disabled_keepalive_derives_to_zero(self):
+        self.assertEqual(_client_idle_timeout_ms_for(0), 0)
+
+    def test_disabling_keepalive_omits_idle_timeout_option_too(self):
+        """keepalive_time_ms=0 must disable BOTH the ping-based and the
+        idle-close detection — a partial disable would be a surprising,
+        undocumented middle state."""
+        _, mock_secure_channel = _build_client(keepalive_time_ms=0)
+        mock_secure_channel.assert_called_once()
+        _, kwargs = mock_secure_channel.call_args
+        options = kwargs["options"]
+        self.assertEqual(options, [])
+        self.assertNotIn(
+            "grpc.client_idle_timeout_ms",
+            [name for name, _ in options],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This SDK configures gRPC keepalive pings (`grpc.keepalive_time_ms`/`keepalive_timeout_ms`, #195) but never the client-side idle-connection-close timeout — the equivalent of what the Go SDK (`grpcIdleConnTimeout`) and Node SDK (`idleConnectionTimeoutMs`) implement by hand on their self-managed HTTP/2 transports. grpc-core exposes this directly as the `grpc.client_idle_timeout_ms` channel option (gRFC A9); this SDK just never wired it up.

Without it, a fully-idle channel relies entirely on keepalive pings to detect a dead connection — it never proactively transitions so its connection is torn down and lazily recreated *before* the backend's own `MaxConnectionIdle` (5 min, scalekit's `cmd/grpc.go`) closes it first, relying purely on reactive detection instead.

## Changes

- Added `CLIENT_IDLE_TIMEOUT_CEILING_MS` (4 min) and `CLIENT_IDLE_TIMEOUT_PING_CYCLES` (5) — matching the Go SDK's `grpcIdleConnCeiling`/`grpcIdleConnPingCycles` and the Node SDK's `IDLE_CONNECTION_TIMEOUT_CEILING_MS`/`IDLE_PING_CYCLES_BEFORE_CLOSE` **exactly** (same formula, same constants), so all three SDKs land on identical idle-close behavior.
- Derived from `keepalive_time_ms` via `_client_idle_timeout_ms_for` rather than exposed as a separate constructor parameter — for the same reason the ceiling itself is 4 min, not 5: strictly below the backend's actual bound, never equal to it. Landing exactly on the backend's bound is a race (whichever side's timer fires first wins, and the loser writes into a socket the other side just closed), not a fix.
- `keepalive_time_ms=0` (the existing "disable keepalive" escape hatch) now also disables the idle-close timeout, consistent with disabling ping-based detection — a partial disable would be a surprising, undocumented middle state.

## Test plan

- [x] 10 new/updated unit tests in `tests/test_keepalive_channel_options.py` — all passing (mocked `grpc.secure_channel`, no network calls)
- [x] Verified `grpc.client_idle_timeout_ms` is accepted as a valid channel option by the installed `grpcio` (1.75.1) without error
- [x] Confirmed no regression: ran the 5 test files touching `CoreClient`/channel construction (83 tests, all passing)
- [x] Confirmed the pre-existing failures elsewhere in the suite (69 tests, `test_actions.py`/`test_connected_accounts.py`/`test_connection.py` etc.) are unrelated — reproduced identically with this change `git stash`'d out, so not introduced by this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/scalekit-inc/codesmith/scalekit-sdk-python/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791712237&installation_model_id=431434&pr_number=203&repository=scalekit-inc%2Fscalekit-sdk-python&return_to=https%3A%2F%2Fgithub.com%2Fscalekit-inc%2Fscalekit-sdk-python%2Fpull%2F203&signature=f093b60f5ec98aa6fbc0356103371adca78e7f14f7c0c6e4cae80b39263b87c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Added automatic gRPC client idle-timeout management when keepalive is enabled.
  - Idle timeouts adjust to keepalive settings and remain below the backend’s idle limit.
  - Disabling SDK-configured keepalive also disables SDK-managed idle-timeout settings; gRPC-core defaults still apply.
- **Bug Fixes**
  - Improved handling of idle connections to help prevent unexpected backend disconnections.
- **Documentation**
  - Clarified keepalive and idle-timeout behavior in client configuration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->